### PR TITLE
Use python's logging module

### DIFF
--- a/lavalink/Client.py
+++ b/lavalink/Client.py
@@ -1,23 +1,14 @@
-import asyncio
-from datetime import datetime
-
 from .PlayerManager import *
 from .WebSocket import *
 
+import logging
 
-def resolve_log_level(level):
-    if level == 'debug':
-        return 0
-    elif level == 'info':
-        return 1
-    elif level == 'warn':
-        return 2
-    elif level == 'error':
-        return 3
-    elif level == 'off':
-        return 4
-    else:
-        return 0
+log = logging.getLogger(__name__)
+
+
+def set_log_level(log_level):
+    root_log = logging.getLogger(__name__.split('.')[0])
+    root_log.setLevel(log_level)
 
 
 class Lavalink:
@@ -32,7 +23,8 @@ class Client:
         self.http = bot.http._session  # Let's use the bot's http session instead
         self.voice_state = {}
         self.hooks = []
-        self.log_level = resolve_log_level(kwargs.pop('log_level', 'info'))
+
+        set_log_level(kwargs.pop('log_level', logging.INFO))
 
         self.bot = bot
         self.bot.add_listener(self.on_socket_response)
@@ -75,7 +67,7 @@ class Client:
             p.position_timestamp = data['state']['time']
 
     async def get_tracks(self, query):
-        self.log('debug', 'Requesting tracks for query ' + query)
+        log.debug('Requesting tracks for query ' + query)
         async with self.http.get(self.rest_uri + query, headers={'Authorization': self.password}) as res:
             js = await res.json(content_type=None)
             res.close()
@@ -113,7 +105,3 @@ class Client:
         self.hooks.clear()
         self.bot.lavalink.client = None
 
-    def log(self, level, content):
-        lvl = resolve_log_level(level)
-        if lvl >= self.log_level:
-            print('[{}] [lavalink.py] [{}] {}'.format(datetime.utcnow().strftime('%H:%M:%S'), level, content))

--- a/lavalink/WebSocket.py
+++ b/lavalink/WebSocket.py
@@ -1,12 +1,14 @@
 import asyncio
 import websockets
 import json
+import logging
+
+log = logging.getLogger(__name__)
 
 
 class WebSocket:
     def __init__(self, lavalink, **kwargs):
         self._lavalink = lavalink
-        self.log = self._lavalink.log
 
         self._ws = None
         self._queue = []
@@ -26,7 +28,7 @@ class WebSocket:
         await self._lavalink.bot.wait_until_ready()
 
         if self._ws and self._ws.open:
-            self.log('debug', 'Websocket still open, closing...')
+            log.debug('Websocket still open, closing...')
             self._ws.close()
 
         user_id = self._lavalink.bot.user.id
@@ -37,20 +39,20 @@ class WebSocket:
             'Num-Shards': shard_count,
             'User-Id': user_id
         }
-        self.log('debug', 'Preparing to connect to Lavalink')
-        self.log('debug', '    with URI: {}'.format(self._uri))
-        self.log('debug', '    with headers: {}'.format(str(headers)))
-        self.log('info', 'Connecting to Lavalink...')
+        log.debug('Preparing to connect to Lavalink')
+        log.debug('    with URI: {}'.format(self._uri))
+        log.debug('    with headers: {}'.format(str(headers)))
+        log.info('Connecting to Lavalink...')
 
         try:
             self._ws = await websockets.connect(self._uri, extra_headers=headers)
         except OSError:
-            self.log('error', 'Failed to connect to Lavalink. ')
+            log.exception('Failed to connect to Lavalink. ')
         else:
-            self.log('info', 'Connected to Lavalink!')
+            log.info('Connected to Lavalink!')
             self._loop.create_task(self.listen())
             if self._queue:
-                self.log('info', 'Replaying {} queued events...'.format(len(self._queue)))
+                log.info('Replaying {} queued events...'.format(len(self._queue)))
                 for task in self._queue:
                     await self.send(**task)
 
@@ -59,10 +61,10 @@ class WebSocket:
             while self._ws.open:
                 data = json.loads(await self._ws.recv())
                 op = data.get('op', None)
-                self.log('debug', 'Received websocket data\n' + str(data))
+                log.debug('Received websocket data\n' + str(data))
 
                 if not op:
-                    return self.log('debug', 'Received websocket message without op\n' + str(data))
+                    return log.debug('Received websocket message without op\n' + str(data))
 
                 if op == 'event':
                     await self._lavalink._trigger_event(data['type'], data['guildId'], data.get('reason', data['type']))
@@ -71,23 +73,23 @@ class WebSocket:
         except websockets.ConnectionClosed:
             self._lavalink.bot.lavalink.players.clear()
 
-            self.log('info', 'Connection closed; attempting to reconnect in 30 seconds')
+            log.info('Connection closed; attempting to reconnect in 30 seconds')
             self._ws.close()
             for a in range(0, self._ws_retry):
                 await asyncio.sleep(30)
-                self.log('info', 'Reconnecting... (Attempt {})'.format(a + 1))
+                log.info('Reconnecting... (Attempt {})'.format(a + 1))
                 await self.connect()
 
                 if self._ws.open:
                     return
 
-            self.log('warn', 'Unable to reconnect to Lavalink!')
+            log.warn('Unable to reconnect to Lavalink!')
 
     async def send(self, **data):
         """ Sends data to lavalink """
         if not self._ws or not self._ws:
             self._queue.append(data)
-            self.log('debug', 'Websocket not ready; appending payload to queue\n' + str(data))
+            log.debug('Websocket not ready; appending payload to queue\n' + str(data))
         else:
-            self.log('debug', 'Sending payload:\n' + str(data))
+            log.debug('Sending payload:\n' + str(data))
             await self._ws.send(json.dumps(data))

--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -11,3 +11,19 @@ from .PlayerManager import *
 from .Utils import *
 from .WebSocket import *
 from .Events import *
+
+import logging
+import sys
+
+log = logging.getLogger(__name__)
+
+fmt = logging.Formatter(
+    '[%(asctime)s] [lavalink.py] [%(levelname)s] %(message)s',
+    datefmt="%H:%M:%S"
+)
+
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(fmt)
+log.addHandler(handler)
+
+log.setLevel(logging.INFO)


### PR DESCRIPTION
This PR makes use of python's built in logging module and makes it so you don't have to pass around a log function.

To use in other modules:
```py
import logging
log = logging.getLogger(__name__)
```