### PR TITLE
Explicitly list keyword arguments for Client

### DIFF
--- a/lavalink/Client.py
+++ b/lavalink/Client.py
@@ -28,22 +28,25 @@ class Lavalink:
 
 
 class Client:
-    def __init__(self, bot, **kwargs):
+    def __init__(self, bot, log_level='info', loop=asyncio.get_event_loop(), host='localhost',
+                 rest_port=2333, password='', ws_retry=3, ws_port=80, shard_count=1):
         self.http = bot.http._session  # Let's use the bot's http session instead
         self.voice_state = {}
         self.hooks = []
-        self.log_level = resolve_log_level(kwargs.pop('log_level', 'info'))
+        self.log_level = resolve_log_level(log_level)
 
         self.bot = bot
         self.bot.add_listener(self.on_socket_response)
 
-        self.loop = kwargs.pop('loop', asyncio.get_event_loop())
-        self.rest_uri = 'http://{}:{}/loadtracks?identifier='.format(kwargs.get('host', 'localhost'), kwargs.pop('rest', 2333))
-        self.password = kwargs.get('password', '')
+        self.loop = loop
+        self.rest_uri = 'http://{}:{}/loadtracks?identifier='.format(host, rest_port)
+        self.password = password
 
         if not hasattr(self.bot, 'lavalink'):
             self.bot.lavalink = Lavalink(self.bot)
-            self.bot.lavalink.ws = WebSocket(self, **kwargs)
+            self.bot.lavalink.ws = WebSocket(
+                self, host, password, ws_port, ws_retry, shard_count
+            )
 
         if not self.bot.lavalink.client:
             self.bot.lavalink.client = self

--- a/lavalink/WebSocket.py
+++ b/lavalink/WebSocket.py
@@ -4,19 +4,19 @@ import json
 
 
 class WebSocket:
-    def __init__(self, lavalink, **kwargs):
+    def __init__(self, lavalink, host, password, ws_port, ws_retry, shard_count):
         self._lavalink = lavalink
         self.log = self._lavalink.log
 
         self._ws = None
         self._queue = []
 
-        self._ws_retry = kwargs.pop('ws_retry', 3)
-        self._password = kwargs.get('password', '')
-        self._host = kwargs.get('host', 'localhost')
-        self._port = kwargs.pop('port', 80)
+        self._ws_retry = ws_retry
+        self._password = password
+        self._host = host
+        self._port = ws_port
         self._uri = 'ws://{}:{}'.format(self._host, self._port)
-        self._shards = kwargs.pop('shard_count', 1)
+        self._shards = shard_count
 
         self._loop = self._lavalink.loop
         self._loop.create_task(self.connect())


### PR DESCRIPTION
This makes it much clearer as to what's expected, having a catchall `kwargs` is unnecessarily vague and confusing.

Two breaking changes were made:
* `rest` was renamed to `rest_port`
* `port` was renamed to `ws_port`