### PR TITLE
Remove dynamic injection and refactor websocket for shutdown

### DIFF
--- a/lavalink/Client.py
+++ b/lavalink/Client.py
@@ -34,7 +34,7 @@ class Client:
         self.ws = WebSocket(
             self, host, password, ws_port, ws_retry, shard_count
         )
-        self.players = PlayerManager(bot)
+        self.players = PlayerManager(bot, self)
 
     def register_hook(self, func):
         if func not in self.hooks:

--- a/lavalink/Client.py
+++ b/lavalink/Client.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import aiohttp
 
 from .PlayerManager import *
 from .WebSocket import *
@@ -12,17 +13,10 @@ def set_log_level(log_level):
     root_log.setLevel(log_level)
 
 
-class Lavalink:
-    def __init__(self, bot):
-        self.client = None
-        self.players = PlayerManager(bot)
-        self.ws = None
-
-
 class Client:
     def __init__(self, bot, log_level=logging.INFO, loop=asyncio.get_event_loop(), host='localhost',
                  rest_port=2333, password='', ws_retry=3, ws_port=80, shard_count=1):
-        self.http = bot.http._session  # Let's use the bot's http session instead
+        self.http = aiohttp.ClientSession(loop=bot.loop)
         self.voice_state = {}
         self.hooks = []
 
@@ -31,18 +25,16 @@ class Client:
         self.bot = bot
         self.bot.add_listener(self.on_socket_response)
 
+        self.user_id = self.bot.user.id
+
         self.loop = loop
         self.rest_uri = 'http://{}:{}/loadtracks?identifier='.format(host, rest_port)
         self.password = password
 
-        if not hasattr(self.bot, 'lavalink'):
-            self.bot.lavalink = Lavalink(self.bot)
-            self.bot.lavalink.ws = WebSocket(
-                self, host, password, ws_port, ws_retry, shard_count
-            )
-
-        if not self.bot.lavalink.client:
-            self.bot.lavalink.client = self
+        self.ws = WebSocket(
+            self, host, password, ws_port, ws_retry, shard_count
+        )
+        self.players = PlayerManager(bot)
 
     def register_hook(self, func):
         if func not in self.hooks:
@@ -52,8 +44,8 @@ class Client:
         if func in self.hooks:
             self.hooks.remove(func)
 
-    async def _trigger_event(self, event: str, guild_id: str, reason: str=''):
-        player = self.bot.lavalink.players[int(guild_id)]
+    async def dispatch_event(self, event: str, guild_id: str, reason: str= ''):
+        player = self.players[int(guild_id)]
 
         if player:
             for hook in self.hooks:
@@ -62,11 +54,11 @@ class Client:
             if event in ['TrackEndEvent', 'TrackExceptionEvent', 'TrackStuckEvent']:
                 await player._on_track_end(reason)
 
-    async def _update_state(self, data):
+    async def update_state(self, data):
         g = int(data['guildId'])
 
-        if self.bot.lavalink.players.has(g):
-            p = self.bot.lavalink.players.get(g)
+        if self.players.has(g):
+            p = self.players.get(g)
             p.position = data['state']['position']
             p.position_timestamp = data['state']['time']
 
@@ -90,21 +82,20 @@ class Client:
                 'event': data['d']
             })
         else:
-            if int(data['d']['user_id']) != self.bot.user.id:
+            if int(data['d']['user_id']) != self.user_id:
                 return
 
             self.voice_state.update({'sessionId': data['d']['session_id']})
 
             guild_id = int(data['d']['guild_id'])
 
-            if self.bot.lavalink.players[guild_id]:
-                self.bot.lavalink.players[guild_id].channel_id = data['d']['channel_id']
+            if self.players[guild_id]:
+                self.players[guild_id].channel_id = data['d']['channel_id']
 
         if {'op', 'guildId', 'sessionId', 'event'} == self.voice_state.keys():
-            await self.bot.lavalink.ws.send(**self.voice_state)
+            await self.ws.send(**self.voice_state)
             self.voice_state.clear()
 
     def destroy(self):
         self.bot.remove_listener(self.on_socket_response)
         self.hooks.clear()
-        self.bot.lavalink.client = None

--- a/lavalink/Client.py
+++ b/lavalink/Client.py
@@ -97,5 +97,6 @@ class Client:
             self.voice_state.clear()
 
     def destroy(self):
+        self.ws.destroy()
         self.bot.remove_listener(self.on_socket_response)
         self.hooks.clear()

--- a/lavalink/Client.py
+++ b/lavalink/Client.py
@@ -32,7 +32,7 @@ class Client:
         self.ws = WebSocket(
             self, host, password, ws_port, ws_retry, shard_count
         )
-        self.players = PlayerManager(bot, self)
+        self.players = PlayerManager(self)
 
     def register_hook(self, func):
         if func not in self.hooks:

--- a/lavalink/Client.py
+++ b/lavalink/Client.py
@@ -16,7 +16,7 @@ def set_log_level(log_level):
 class Client:
     def __init__(self, bot, log_level=logging.INFO, loop=asyncio.get_event_loop(), host='localhost',
                  rest_port=2333, password='', ws_retry=3, ws_port=80, shard_count=1):
-        self.http = aiohttp.ClientSession(loop=bot.loop)
+        self.http = aiohttp.ClientSession(loop=loop)
         self.voice_state = {}
         self.hooks = []
 
@@ -24,8 +24,6 @@ class Client:
 
         self.bot = bot
         self.bot.add_listener(self.on_socket_response)
-
-        self.user_id = self.bot.user.id
 
         self.loop = loop
         self.rest_uri = 'http://{}:{}/loadtracks?identifier='.format(host, rest_port)
@@ -82,7 +80,7 @@ class Client:
                 'event': data['d']
             })
         else:
-            if int(data['d']['user_id']) != self.user_id:
+            if int(data['d']['user_id']) != self.bot.user.id:
                 return
 
             self.voice_state.update({'sessionId': data['d']['session_id']})

--- a/lavalink/Player.py
+++ b/lavalink/Player.py
@@ -40,7 +40,8 @@ class Player:
 
     async def connect(self, channel_id: int):
         """ Connects to a voicechannel """
-        await self._lavalink.bot.ws.voice_state(self.guild_id, str(channel_id))
+        ws = self._lavalink.bot._connection._get_websocket(int(self.guild_id))
+        await ws.voice_state(self.guild_id, str(channel_id))
 
     async def disconnect(self):
         """ Disconnects from the voicechannel, if any """
@@ -49,7 +50,8 @@ class Player:
 
         await self.stop()
 
-        await self._lavalink.bot.ws.voice_state(self.guild_id, None)
+        ws = self._lavalink.bot._connection._get_websocket(int(self.guild_id))
+        await ws.voice_state(self.guild_id, None)
 
     def store(self, key: object, value: object):
         """ Stores the key and value in the internal storage """

--- a/lavalink/Player.py
+++ b/lavalink/Player.py
@@ -4,8 +4,7 @@ from .AudioTrack import *
 
 
 class Player:
-    def __init__(self, bot, lavalink, guild_id: int):
-        self._bot = bot
+    def __init__(self, lavalink, guild_id: int):
         self._lavalink = lavalink
         self._user_data = {}
         self.guild_id = str(guild_id)
@@ -37,7 +36,7 @@ class Player:
         if not self.channel_id:
             return None
 
-        return self._bot.get_channel(int(self.channel_id))
+        return self._lavalink.bot.get_channel(int(self.channel_id))
 
     async def connect(self, channel_id: int):
         """ Connects to a voicechannel """
@@ -50,7 +49,7 @@ class Player:
                 'self_deaf': False
             }
         }
-        await self._bot._connection._get_websocket(int(self.guild_id)).send(json.dumps(payload))
+        await self._lavalink.bot._connection._get_websocket(int(self.guild_id)).send(json.dumps(payload))
 
     async def disconnect(self):
         """ Disconnects from the voicechannel, if any """
@@ -69,7 +68,7 @@ class Player:
             }
         }
 
-        await self._bot._connection._get_websocket(int(self.guild_id)).send(json.dumps(payload))
+        await self._lavalink.bot._connection._get_websocket(int(self.guild_id)).send(json.dumps(payload))
 
     def store(self, key: object, value: object):
         """ Stores the key and value in the internal storage """

--- a/lavalink/Player.py
+++ b/lavalink/Player.py
@@ -4,8 +4,9 @@ from .AudioTrack import *
 
 
 class Player:
-    def __init__(self, bot, guild_id: int):
+    def __init__(self, bot, lavalink, guild_id: int):
         self._bot = bot
+        self._lavalink = lavalink
         self._user_data = {}
         self.guild_id = str(guild_id)
         self.channel_id = None
@@ -104,7 +105,7 @@ class Player:
 
         if not self.queue:
             await self.stop()
-            await self._bot.lavalink.client.dispatch_event('QueueEndEvent', self.guild_id)
+            await self._lavalink.dispatch_event('QueueEndEvent', self.guild_id)
         else:
             if self.shuffle:
                 track = self.queue.pop(randrange(len(self.queue)))
@@ -112,12 +113,12 @@ class Player:
                 track = self.queue.pop(0)
 
             self.current = track
-            await self._bot.lavalink.ws.send(op='play', guildId=self.guild_id, track=track.track)
-            await self._bot.lavalink.client.dispatch_event('TrackStartEvent', self.guild_id)
+            await self._lavalink.ws.send(op='play', guildId=self.guild_id, track=track.track)
+            await self._lavalink.dispatch_event('TrackStartEvent', self.guild_id)
 
     async def stop(self):
         """ Stops the player, if playing """
-        await self._bot.lavalink.ws.send(op='stop', guildId=self.guild_id)
+        await self._lavalink.ws.send(op='stop', guildId=self.guild_id)
         self.current = None
 
     async def skip(self):
@@ -126,18 +127,18 @@ class Player:
 
     async def set_pause(self, pause: bool):
         """ Sets the player's paused state """
-        await self._bot.lavalink.ws.send(op='pause', guildId=self.guild_id, pause=pause)
+        await self._lavalink.ws.send(op='pause', guildId=self.guild_id, pause=pause)
         self.paused = pause
 
     async def set_volume(self, vol: int):
         """ Sets the player's volume (150% limit imposed by lavalink) """
         self.volume = max(min(vol, 150), 0)
-        await self._bot.lavalink.ws.send(op='volume', guildId=self.guild_id, volume=self.volume)
+        await self._lavalink.ws.send(op='volume', guildId=self.guild_id, volume=self.volume)
 
     async def seek(self, pos: int):
         """ Seeks to a given position in the track """
         pos = max(pos, 0)  # Prevent seeking before start of track
-        await self._bot.lavalink.ws.send(op='seek', guildId=self.guild_id, position=pos)
+        await self._lavalink.ws.send(op='seek', guildId=self.guild_id, position=pos)
 
     async def _on_track_end(self, reason: str):
         if reason in ['FINISHED', 'TrackStuckEvent', 'TrackExceptionEvent']:

--- a/lavalink/Player.py
+++ b/lavalink/Player.py
@@ -40,16 +40,7 @@ class Player:
 
     async def connect(self, channel_id: int):
         """ Connects to a voicechannel """
-        payload = {
-            'op': 4,
-            'd': {
-                'guild_id': self.guild_id,
-                'channel_id': str(channel_id),
-                'self_mute': False,
-                'self_deaf': False
-            }
-        }
-        await self._lavalink.bot._connection._get_websocket(int(self.guild_id)).send(json.dumps(payload))
+        await self._lavalink.bot.ws.voice_state(self.guild_id, str(channel_id))
 
     async def disconnect(self):
         """ Disconnects from the voicechannel, if any """
@@ -58,17 +49,7 @@ class Player:
 
         await self.stop()
 
-        payload = {
-            'op': 4,
-            'd': {
-                'guild_id': self.guild_id,
-                'channel_id': None,
-                'self_mute': False,
-                'self_deaf': False
-            }
-        }
-
-        await self._lavalink.bot._connection._get_websocket(int(self.guild_id)).send(json.dumps(payload))
+        await self._lavalink.bot.ws.voice_state(self.guild_id, None)
 
     def store(self, key: object, value: object):
         """ Stores the key and value in the internal storage """

--- a/lavalink/Player.py
+++ b/lavalink/Player.py
@@ -104,7 +104,7 @@ class Player:
 
         if not self.queue:
             await self.stop()
-            await self._bot.lavalink.client._trigger_event('QueueEndEvent', self.guild_id)
+            await self._bot.lavalink.client.dispatch_event('QueueEndEvent', self.guild_id)
         else:
             if self.shuffle:
                 track = self.queue.pop(randrange(len(self.queue)))
@@ -113,7 +113,7 @@ class Player:
 
             self.current = track
             await self._bot.lavalink.ws.send(op='play', guildId=self.guild_id, track=track.track)
-            await self._bot.lavalink.client._trigger_event('TrackStartEvent', self.guild_id)
+            await self._bot.lavalink.client.dispatch_event('TrackStartEvent', self.guild_id)
 
     async def stop(self):
         """ Stops the player, if playing """

--- a/lavalink/PlayerManager.py
+++ b/lavalink/PlayerManager.py
@@ -8,8 +8,7 @@ from .Player import *
 
 
 class PlayerManager:
-    def __init__(self, bot, lavalink):
-        self.bot = bot
+    def __init__(self, lavalink):
         self.lavalink = lavalink
         self._players = {}
 
@@ -34,7 +33,7 @@ class PlayerManager:
     def get(self, guild_id):
         """ Returns a player from the cache, or creates one if it does not exist """
         if guild_id not in self._players:
-            p = Player(bot=self.bot, lavalink=self.lavalink, guild_id=guild_id)
+            p = Player(lavalink=self.lavalink, guild_id=guild_id)
             self._players[guild_id] = p
 
         return self._players[guild_id]
@@ -68,8 +67,8 @@ class BasePlayer(ABC):
 
 
 class DefaultPlayer(BasePlayer):
-    def __init__(self, bot, lavalink, guild_id: int):
-        self._bot = bot
+    def __init__(self, lavalink, guild_id: int):
+        super().__init__(guild_id)
         self._lavalink = lavalink
         self._user_data = {}
         self.guild_id = str(guild_id)
@@ -101,7 +100,7 @@ class DefaultPlayer(BasePlayer):
         if not self.channel_id:
             return None
 
-        return self._bot.get_channel(int(self.channel_id))
+        return self._lavalink.bot.get_channel(int(self.channel_id))
 
     async def connect(self, channel_id: int):
         """ Connects to a voicechannel """
@@ -114,7 +113,7 @@ class DefaultPlayer(BasePlayer):
                 'self_deaf': False
             }
         }
-        await self._bot._connection._get_websocket(int(self.guild_id)).send(json.dumps(payload))
+        await self._lavalink.bot._connection._get_websocket(int(self.guild_id)).send(json.dumps(payload))
 
     async def disconnect(self):
         """ Disconnects from the voicechannel, if any """
@@ -133,7 +132,7 @@ class DefaultPlayer(BasePlayer):
             }
         }
 
-        await self._bot._connection._get_websocket(int(self.guild_id)).send(json.dumps(payload))
+        await self._lavalink.bot._connection._get_websocket(int(self.guild_id)).send(json.dumps(payload))
 
     def store(self, key: object, value: object):
         """ Stores custom user data """

--- a/lavalink/PlayerManager.py
+++ b/lavalink/PlayerManager.py
@@ -104,16 +104,7 @@ class DefaultPlayer(BasePlayer):
 
     async def connect(self, channel_id: int):
         """ Connects to a voicechannel """
-        payload = {
-            'op': 4,
-            'd': {
-                'guild_id': self.guild_id,
-                'channel_id': str(channel_id),
-                'self_mute': False,
-                'self_deaf': False
-            }
-        }
-        await self._lavalink.bot._connection._get_websocket(int(self.guild_id)).send(json.dumps(payload))
+        await self._lavalink.bot.ws.voice_state(self.guild_id, str(channel_id))
 
     async def disconnect(self):
         """ Disconnects from the voicechannel, if any """
@@ -122,17 +113,7 @@ class DefaultPlayer(BasePlayer):
 
         await self.stop()
 
-        payload = {
-            'op': 4,
-            'd': {
-                'guild_id': self.guild_id,
-                'channel_id': None,
-                'self_mute': False,
-                'self_deaf': False
-            }
-        }
-
-        await self._lavalink.bot._connection._get_websocket(int(self.guild_id)).send(json.dumps(payload))
+        await self._lavalink.bot.ws.voice_state(self.guild_id, None)
 
     def store(self, key: object, value: object):
         """ Stores custom user data """

--- a/lavalink/PlayerManager.py
+++ b/lavalink/PlayerManager.py
@@ -104,7 +104,8 @@ class DefaultPlayer(BasePlayer):
 
     async def connect(self, channel_id: int):
         """ Connects to a voicechannel """
-        await self._lavalink.bot.ws.voice_state(self.guild_id, str(channel_id))
+        ws = self._lavalink.bot._connection._get_websocket(int(self.guild_id))
+        await ws.voice_state(self.guild_id, str(channel_id))
 
     async def disconnect(self):
         """ Disconnects from the voicechannel, if any """
@@ -113,7 +114,8 @@ class DefaultPlayer(BasePlayer):
 
         await self.stop()
 
-        await self._lavalink.bot.ws.voice_state(self.guild_id, None)
+        ws = self._lavalink.bot._connection._get_websocket(int(self.guild_id))
+        await ws.voice_state(self.guild_id, None)
 
     def store(self, key: object, value: object):
         """ Stores custom user data """

--- a/lavalink/PlayerManager.py
+++ b/lavalink/PlayerManager.py
@@ -156,7 +156,7 @@ class DefaultPlayer(BasePlayer):
 
         if not self.queue:
             await self.stop()
-            await self._bot.lavalink.client._trigger_event('QueueEndEvent', self.guild_id)
+            await self._bot.lavalink.client.dispatch_event('QueueEndEvent', self.guild_id)
         else:
             if self.shuffle:
                 track = self.queue.pop(randrange(len(self.queue)))
@@ -165,7 +165,7 @@ class DefaultPlayer(BasePlayer):
 
             self.current = track
             await self._bot.lavalink.ws.send(op='play', guildId=self.guild_id, track=track.track)
-            await self._bot.lavalink.client._trigger_event('TrackStartEvent', self.guild_id)
+            await self._bot.lavalink.client.dispatch_event('TrackStartEvent', self.guild_id)
 
     async def stop(self):
         """ Stops the player, if playing """

--- a/lavalink/PlayerManager.py
+++ b/lavalink/PlayerManager.py
@@ -8,8 +8,9 @@ from .Player import *
 
 
 class PlayerManager:
-    def __init__(self, bot):
+    def __init__(self, bot, lavalink):
         self.bot = bot
+        self.lavalink = lavalink
         self._players = {}
 
     def __len__(self):
@@ -33,7 +34,7 @@ class PlayerManager:
     def get(self, guild_id):
         """ Returns a player from the cache, or creates one if it does not exist """
         if guild_id not in self._players:
-            p = Player(bot=self.bot, guild_id=guild_id)
+            p = Player(bot=self.bot, lavalink=self.lavalink, guild_id=guild_id)
             self._players[guild_id] = p
 
         return self._players[guild_id]
@@ -67,8 +68,9 @@ class BasePlayer(ABC):
 
 
 class DefaultPlayer(BasePlayer):
-    def __init__(self, bot, guild_id: int):
+    def __init__(self, bot, lavalink, guild_id: int):
         self._bot = bot
+        self._lavalink = lavalink
         self._user_data = {}
         self.guild_id = str(guild_id)
         self.channel_id = None
@@ -156,7 +158,7 @@ class DefaultPlayer(BasePlayer):
 
         if not self.queue:
             await self.stop()
-            await self._bot.lavalink.client.dispatch_event('QueueEndEvent', self.guild_id)
+            await self._lavalink.dispatch_event('QueueEndEvent', self.guild_id)
         else:
             if self.shuffle:
                 track = self.queue.pop(randrange(len(self.queue)))
@@ -164,12 +166,12 @@ class DefaultPlayer(BasePlayer):
                 track = self.queue.pop(0)
 
             self.current = track
-            await self._bot.lavalink.ws.send(op='play', guildId=self.guild_id, track=track.track)
-            await self._bot.lavalink.client.dispatch_event('TrackStartEvent', self.guild_id)
+            await self._lavalink.ws.send(op='play', guildId=self.guild_id, track=track.track)
+            await self._lavalink.dispatch_event('TrackStartEvent', self.guild_id)
 
     async def stop(self):
         """ Stops the player, if playing """
-        await self._bot.lavalink.ws.send(op='stop', guildId=self.guild_id)
+        await self._lavalink.ws.send(op='stop', guildId=self.guild_id)
         self.current = None
 
     async def skip(self):
@@ -178,17 +180,17 @@ class DefaultPlayer(BasePlayer):
 
     async def set_pause(self, pause: bool):
         """ Sets the player's paused state """
-        await self._bot.lavalink.ws.send(op='pause', guildId=self.guild_id, pause=pause)
+        await self._lavalink.ws.send(op='pause', guildId=self.guild_id, pause=pause)
         self.paused = pause
 
     async def set_volume(self, vol: int):
         """ Sets the player's volume (150% limit imposed by lavalink) """
         self.volume = max(min(vol, 150), 0)
-        await self._bot.lavalink.ws.send(op='volume', guildId=self.guild_id, volume=self.volume)
+        await self._lavalink.ws.send(op='volume', guildId=self.guild_id, volume=self.volume)
 
     async def seek(self, pos: int):
         """ Seeks to a given position in the track """
-        await self._bot.lavalink.ws.send(op='seek', guildId=self.guild_id, position=pos)
+        await self._lavalink.ws.send(op='seek', guildId=self.guild_id, position=pos)
 
     async def _handle_event(self, event):
         if isinstance(event, (TrackStartEvent, TrackExceptionEvent)) or \

--- a/lavalink/WebSocket.py
+++ b/lavalink/WebSocket.py
@@ -67,11 +67,13 @@ class WebSocket:
                     return log.debug('Received websocket message without op\n' + str(data))
 
                 if op == 'event':
-                    await self._lavalink._trigger_event(data['type'], data['guildId'], data.get('reason', data['type']))
+                    await self._lavalink.dispatch_event(
+                        data['type'], data['guildId'], data.get('reason', data['type'])
+                    )
                 elif op == 'playerUpdate':
-                    await self._lavalink._update_state(data)
+                    await self._lavalink.update_state(data)
         except websockets.ConnectionClosed:
-            self._lavalink.bot.lavalink.players.clear()
+            self._lavalink.players.clear()
 
             log.info('Connection closed; attempting to reconnect in 30 seconds')
             self._ws.close()
@@ -83,7 +85,7 @@ class WebSocket:
                 if self._ws.open:
                     return
 
-            log.warn('Unable to reconnect to Lavalink!')
+            log.warning('Unable to reconnect to Lavalink!')
 
     async def send(self, **data):
         """ Sends data to lavalink """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 websockets>=4.0.0
+aiohttp


### PR DESCRIPTION
This PR accomplishes 2 things:
* Removes dynamic injection of `Lavalink` object into `discord.Client`, it felt dirty and definitely didn't help performance (in 3.6+ at least)
  * All operations should now be performed on the `lavalink.Client` object.
* Refactor the websocket code a bit to enable a graceful shutdown