### PR TITLE
Better check for URLs in examples

### DIFF
--- a/examples/music-v2.py
+++ b/examples/music-v2.py
@@ -53,8 +53,10 @@ class Music:
                 return await ctx.send('Join my voice channel!')
 
         query = query.strip('<>')
-
-        if not query.startswith('http'):
+        linksRegex = '((http(s):[/][/]|www.)([a-z]|[A-Z]|[0-9]|[/.]|[~]))'
+        pattern = re.compile(linksRegex)   
+        
+        if not pattern.match(query): 
             query = f'ytsearch:{query}'
 
         tracks = await self.bot.lavalink.get_tracks(query)

--- a/examples/music-v2.py
+++ b/examples/music-v2.py
@@ -7,6 +7,7 @@ import lavalink
 from discord.ext import commands
 
 time_rx = re.compile('[0-9]+')
+url_rx = re.compile('((http(s):[/][/]|www.)([a-z]|[A-Z]|[0-9]|[/.]|[~]))')  
 
 
 class Music:
@@ -53,10 +54,8 @@ class Music:
                 return await ctx.send('Join my voice channel!')
 
         query = query.strip('<>')
-        linksRegex = '((http(s):[/][/]|www.)([a-z]|[A-Z]|[0-9]|[/.]|[~]))'
-        pattern = re.compile(linksRegex)   
         
-        if not pattern.match(query): 
+        if not url_rx.match(query): 
             query = f'ytsearch:{query}'
 
         tracks = await self.bot.lavalink.get_tracks(query)

--- a/examples/music-v3.py
+++ b/examples/music-v3.py
@@ -53,8 +53,10 @@ class Music:
                 return await ctx.send('Join my voice channel!')
 
         query = query.strip('<>')
-
-        if not query.startswith('http'):
+        linksRegex = '((http(s):[/][/]|www.)([a-z]|[A-Z]|[0-9]|[/.]|[~]))'
+        pattern = re.compile(linksRegex)   
+        
+        if not pattern.match(query): 
             query = f'ytsearch:{query}'
 
         results = await self.bot.lavalink.get_tracks(query)

--- a/examples/music-v3.py
+++ b/examples/music-v3.py
@@ -7,6 +7,7 @@ import lavalink
 from discord.ext import commands
 
 time_rx = re.compile('[0-9]+')
+url_rx = re.compile('((http(s):[/][/]|www.)([a-z]|[A-Z]|[0-9]|[/.]|[~]))')  
 
 
 class Music:
@@ -52,11 +53,9 @@ class Music:
             if not ctx.author.voice or not ctx.author.voice.channel or player.connected_channel.id != ctx.author.voice.channel.id:
                 return await ctx.send('Join my voice channel!')
 
-        query = query.strip('<>')
-        linksRegex = '((http(s):[/][/]|www.)([a-z]|[A-Z]|[0-9]|[/.]|[~]))'
-        pattern = re.compile(linksRegex)   
+        query = query.strip('<>') 
         
-        if not pattern.match(query): 
+        if not url_rx.match(query): 
             query = f'ytsearch:{query}'
 
         results = await self.bot.lavalink.get_tracks(query)


### PR DESCRIPTION
Allows to avoid the following hacks : 

- A song query starting with `http`
- A song URL starting with `www.`