### PR TITLE
Added add_to_top and karaoke mode.

### DIFF
--- a/lavalink/PlayerManager.py
+++ b/lavalink/PlayerManager.py
@@ -137,7 +137,7 @@ class DefaultPlayer(BasePlayer):
         """ Seeks to a given position in the track. """
         await self._lavalink.ws.send(op='seek', guildId=self.guild_id, position=pos)
     
-    def toggle_karaoke(self, state):
+    def toggle_karaoke(self):
         self.karaoke = not self.karaoke
 
     async def handle_event(self, event):

--- a/lavalink/PlayerManager.py
+++ b/lavalink/PlayerManager.py
@@ -86,6 +86,10 @@ class DefaultPlayer(BasePlayer):
     def add(self, requester: int, track: dict):
         """ Adds a track to the queue. """
         self.queue.append(AudioTrack().build(track, requester))
+        
+    def add_to_top(self, requester: int, track: dict):
+        """ Adds a track to the queue. """
+        self.queue = [AudioTrack().build(track, requester)] + self.queue
 
     async def play(self):
         """ Plays the first track in the queue, if any. """

--- a/lavalink/PlayerManager.py
+++ b/lavalink/PlayerManager.py
@@ -137,7 +137,7 @@ class DefaultPlayer(BasePlayer):
         """ Seeks to a given position in the track. """
         await self._lavalink.ws.send(op='seek', guildId=self.guild_id, position=pos)
     
-    def toggle_karaoke(self, state)
+    def toggle_karaoke(self, state):
         self.karaoke = not self.karaoke
 
     async def handle_event(self, event):

--- a/lavalink/PlayerManager.py
+++ b/lavalink/PlayerManager.py
@@ -31,6 +31,7 @@ class DefaultPlayer(BasePlayer):
         self.volume = 100
         self.shuffle = False
         self.repeat = False
+        self.karaoke = False
 
         self.queue = []
         self.current = None
@@ -135,6 +136,9 @@ class DefaultPlayer(BasePlayer):
     async def seek(self, pos: int):
         """ Seeks to a given position in the track. """
         await self._lavalink.ws.send(op='seek', guildId=self.guild_id, position=pos)
+    
+    def toggle_karaoke(self, state)
+        self.karaoke = not self.karaoke
 
     async def handle_event(self, event):
         """ Makes the player play the next song from the queue if a song has finished or an issue occurred. """

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     author='Devoxin',
     author_email='luke@serux.pro',
     url='https://github.com/Devoxin/Lavalink.py',
-    download_url='https://github.com/Devoxin/Lavalink.py/archive/2.1.9.tar.gz',
+    download_url='https://github.com/Devoxin/Lavalink.py/archive/2.2.0.tar.gz',
     keywords=['lavalink'],
     include_package_data=True,
     install_requires=['websockets!=5.0.0', 'aiohttp']

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(
     name='lavalink',
     packages=['lavalink'],
-    version='2.1.9',
+    version='2.2.0',
     description='A lavalink interface built for discord.py',
     author='Devoxin',
     author_email='luke@serux.pro',


### PR DESCRIPTION
You can do ``player.add_to_top(requester, track)`` just like ``player.add(requester, track)`` but it adds the song to the top of the queue.