### PR TITLE
Hacktoberfest updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,5 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+\.idea/

--- a/lavalink/Client.py
+++ b/lavalink/Client.py
@@ -6,6 +6,7 @@ import aiohttp
 
 from .Events import TrackEndEvent, TrackExceptionEvent, TrackStuckEvent
 from .PlayerManager import DefaultPlayer, PlayerManager
+from .Stats import Stats
 from .WebSocket import WebSocket
 
 log = logging.getLogger(__name__)
@@ -62,6 +63,9 @@ class Client:
         self.ws = WebSocket(
             self, host, password, ws_port, ws_retry, shard_count
         )
+        self._server_version = 2
+        self.stats = Stats()
+
         self.players = PlayerManager(self, player)
 
     def register_hook(self, func):
@@ -108,7 +112,8 @@ class Client:
                 else:
                     hook(event)
             except Exception as e:  # Catch generic exception thrown by user hooks
-                log.warning('Encountered exception while dispatching an event to hook `{}` ({})'.format(hook.__name__, str(e)))
+                log.warning(
+                    'Encountered exception while dispatching an event to hook `{}` ({})'.format(hook.__name__, str(e)))
 
         if isinstance(event, (TrackEndEvent, TrackExceptionEvent, TrackStuckEvent)) and event.player is not None:
             await event.player.handle_event(event)

--- a/lavalink/Events.py
+++ b/lavalink/Events.py
@@ -1,6 +1,3 @@
-from .Stats import Stats
-
-
 class QueueEndEvent:
     """ This event will be dispatched when there are no more songs in the queue. """
     def __init__(self, player):
@@ -41,4 +38,4 @@ class TrackStartEvent:
 class StatsUpdateEvent:
     """ This event will be dispatched when the websocket receives a statistics update. """
     def __init__(self, data):
-        self.stats = Stats()._update(data)
+        self.stats = data

--- a/lavalink/Events.py
+++ b/lavalink/Events.py
@@ -1,3 +1,6 @@
+from .Stats import Stats
+
+
 class QueueEndEvent:
     """ This event will be dispatched when there are no more songs in the queue. """
     def __init__(self, player):
@@ -35,7 +38,7 @@ class TrackStartEvent:
         self.track = track
 
 
-class RawStatsUpdateEvent:
+class StatsUpdateEvent:
     """ This event will be dispatched when the websocket receives a statistics update. """
     def __init__(self, data):
-        self.data = data
+        self.stats = Stats()._update(data)

--- a/lavalink/Events.py
+++ b/lavalink/Events.py
@@ -33,3 +33,9 @@ class TrackStartEvent:
     def __init__(self, player, track):
         self.player = player
         self.track = track
+
+
+class RawStatsUpdateEvent:
+    """ This event will be dispatched when the websocket receives a statistics update. """
+    def __init__(self, data):
+        self.data = data

--- a/lavalink/PlayerManager.py
+++ b/lavalink/PlayerManager.py
@@ -169,8 +169,8 @@ class DefaultPlayer(BasePlayer):
 
     async def handle_event(self, event):
         """ Makes the player play the next song from the queue if a song has finished or an issue occurred. """
-        if isinstance(event, (TrackStuckEvent, TrackExceptionEvent)) or isinstance(event,
-                                                                                   TrackEndEvent) and event.reason == 'FINISHED':
+        if isinstance(event, (TrackStuckEvent, TrackExceptionEvent)) or \
+                isinstance(event, TrackEndEvent) and event.reason == 'FINISHED':
             await self.play()
 
 

--- a/lavalink/Stats.py
+++ b/lavalink/Stats.py
@@ -1,0 +1,32 @@
+class Memory:
+    def __init__(self):
+        self.reservable = 0
+        self.free = 0
+        self.used = 0
+        self.allocated = 0
+
+
+class CPU:
+    def __init__(self):
+        self.cores = 0
+        self.system_load = 0.0
+        self.lavalink_load = 0.0
+
+
+class Stats:
+    def __init__(self):
+        self.playing_players = 0
+        self.memory = Memory()
+        self.cpu = CPU()
+        self.uptime = 0
+
+    def _update(self, data: dict):
+        self.playing_players = data.get("playingPlayers", 0)
+        self.memory.reservable = data.get("memory", {}).get("reservable", 0)
+        self.memory.free = data.get("memory", {}).get("free", 0)
+        self.memory.used = data.get("memory", {}).get("used", 0)
+        self.memory.allocated = data.get("memory", {}).get("allocated", 0)
+        self.cpu.cores = data.get("cpu", {}).get("cores", 0)
+        self.cpu.system_load = data.get("cpu", {}).get("systemLoad", 0)
+        self.cpu.lavalink_load = data.get("cpu", {}).get("lavalinkLoad", 0)
+        self.uptime = data.get("uptime", 0)

--- a/lavalink/WebSocket.py
+++ b/lavalink/WebSocket.py
@@ -4,7 +4,7 @@ import logging
 
 import websockets
 
-from .Events import TrackStuckEvent, TrackExceptionEvent, TrackEndEvent
+from .Events import TrackStuckEvent, TrackExceptionEvent, TrackEndEvent, RawStatsUpdateEvent
 
 log = logging.getLogger(__name__)
 
@@ -61,6 +61,12 @@ class WebSocket:
         else:
             log.info('Connected to Lavalink!')
             self._loop.create_task(self.listen())
+            version = self._ws.response_headers.get('Lavalink-Major-Version', 2)
+            try:
+                self._lavalink._server_version = int(version)
+            except ValueError:
+                self._lavalink._server_version = 2
+            log.info('Lavalink server version is {}'.format(version))
             if self._queue:
                 log.info('Replaying {} queued events...'.format(len(self._queue)))
                 for task in self._queue:
@@ -128,6 +134,9 @@ class WebSocket:
                     await self._lavalink.dispatch_event(event)
             elif op == 'playerUpdate':
                 await self._lavalink.update_state(data)
+            elif op == 'stats':
+                self._lavalink.stats._update(data)
+                await self._lavalink.dispatch_event(RawStatsUpdateEvent(data))
 
         log.debug('Closing WebSocket...')
         await self._ws.close()

--- a/lavalink/WebSocket.py
+++ b/lavalink/WebSocket.py
@@ -136,7 +136,7 @@ class WebSocket:
                 await self._lavalink.update_state(data)
             elif op == 'stats':
                 self._lavalink.stats._update(data)
-                await self._lavalink.dispatch_event(StatsUpdateEvent(data))
+                await self._lavalink.dispatch_event(StatsUpdateEvent(self._lavalink.stats))
 
         log.debug('Closing WebSocket...')
         await self._ws.close()

--- a/lavalink/WebSocket.py
+++ b/lavalink/WebSocket.py
@@ -4,7 +4,7 @@ import logging
 
 import websockets
 
-from .Events import TrackStuckEvent, TrackExceptionEvent, TrackEndEvent, RawStatsUpdateEvent
+from .Events import TrackStuckEvent, TrackExceptionEvent, TrackEndEvent, StatsUpdateEvent
 
 log = logging.getLogger(__name__)
 
@@ -136,7 +136,7 @@ class WebSocket:
                 await self._lavalink.update_state(data)
             elif op == 'stats':
                 self._lavalink.stats._update(data)
-                await self._lavalink.dispatch_event(RawStatsUpdateEvent(data))
+                await self._lavalink.dispatch_event(StatsUpdateEvent(data))
 
         log.debug('Closing WebSocket...')
         await self._ws.close()


### PR DESCRIPTION
- Added version detection based on `response_headers` on websocket open.
- Adjusted volume based on lavalink version.
- Added `_server_version` property to indicate lavalink server version.
- Added methods `add_next` and `add_at` for easily adding tracks.
- Added methods `play_next`, `play_at`, `play_from_queue` and `play_previous` for more flexibility.
- Added statistics, accessed by `stats` property in the client. (I know I could do it with namedtuples, but it looks more readable with classes.)
- Added `RawStatsUpdateEvent` to get statistics updates. (Could be used in the future to do load balancing etc.)