### PR TITLE
Lavalink v3.1 Compatibility & Resolving issues with voice events

### DIFF
--- a/lavalink/AudioTrack.py
+++ b/lavalink/AudioTrack.py
@@ -9,8 +9,8 @@ class TrackNotBuilt(Exception):
 
 
 class AudioTrack:
-    __slots__ = ("track", "identifier", "can_seek", "author", "duration", "stream", "title", "uri", "requester",
-                 "preferences")
+    __slots__ = ('track', 'identifier', 'can_seek', 'author', 'duration', 'stream', 'title', 'uri', 'requester',
+                 'preferences')
 
     def __init__(self, requester, **kwargs):
         self.requester = requester
@@ -37,7 +37,7 @@ class AudioTrack:
     @property
     def thumbnail(self):
         """ Returns the video thumbnail. Could be an empty string. """
-        if not hasattr(self, "track"):
+        if not hasattr(self, 'track'):
             raise TrackNotBuilt
         if 'youtube' in self.uri:
             return "https://img.youtube.com/vi/{}/default.jpg".format(self.identifier)
@@ -45,6 +45,6 @@ class AudioTrack:
         return ""
 
     def __repr__(self):
-        if not hasattr(self, "track"):
+        if not hasattr(self, 'track'):
             raise TrackNotBuilt
         return '<AudioTrack title={0.title} identifier={0.identifier}>'.format(self)

--- a/lavalink/AudioTrack.py
+++ b/lavalink/AudioTrack.py
@@ -9,8 +9,8 @@ class TrackNotBuilt(Exception):
 
 
 class AudioTrack:
-    __slots__ = ["track", "identifier", "can_seek", "author", "duration", "stream", "title", "uri", "requester",
-                 "preferences"]
+    __slots__ = ("track", "identifier", "can_seek", "author", "duration", "stream", "title", "uri", "requester",
+                 "preferences")
 
     def __init__(self, requester, **kwargs):
         self.requester = requester

--- a/lavalink/AudioTrack.py
+++ b/lavalink/AudioTrack.py
@@ -9,8 +9,8 @@ class TrackNotBuilt(Exception):
 
 
 class AudioTrack:
-    __slots__ = ("track", "identifier", "can_seek", "author", "duration", "stream", "title", "uri", "requester",
-                 "preferences")
+    __slots__ = ["track", "identifier", "can_seek", "author", "duration", "stream", "title", "uri", "requester",
+                 "preferences"]
 
     def __init__(self, requester, **kwargs):
         self.requester = requester

--- a/lavalink/AudioTrack.py
+++ b/lavalink/AudioTrack.py
@@ -3,32 +3,48 @@ class InvalidTrack(Exception):
     pass
 
 
-class AudioTrack:
-    def build(self, track, requester, **kwargs):
-        """ Returns an optional AudioTrack. """
-        try:
-            self.track = track['track']
-            self.identifier = track['info']['identifier']
-            self.can_seek = track['info']['isSeekable']
-            self.author = track['info']['author']
-            self.duration = track['info']['length']
-            self.stream = track['info']['isStream']
-            self.title = track['info']['title']
-            self.uri = track['info']['uri']
-            self.requester = requester
-            self.preferences = kwargs
+class TrackNotBuilt(Exception):
+    """ This exception will be raised when AudioTrack objects hasn't been built. """
+    pass
 
-            return self
+
+class AudioTrack:
+    __slots__ = ("track", "identifier", "can_seek", "author", "duration", "stream", "title", "uri", "requester",
+                 "preferences")
+
+    def __init__(self, requester, **kwargs):
+        self.requester = requester
+        self.preferences = kwargs
+
+    @classmethod
+    def build(cls, track, requester, **kwargs):
+        """ Returns an optional AudioTrack. """
+        new_track = cls(requester, **kwargs)
+        try:
+            new_track.track = track['track']
+            new_track.identifier = track['info']['identifier']
+            new_track.can_seek = track['info']['isSeekable']
+            new_track.author = track['info']['author']
+            new_track.duration = track['info']['length']
+            new_track.stream = track['info']['isStream']
+            new_track.title = track['info']['title']
+            new_track.uri = track['info']['uri']
+
+            return new_track
         except KeyError:
             raise InvalidTrack('An invalid track was passed.')
 
     @property
     def thumbnail(self):
         """ Returns the video thumbnail. Could be an empty string. """
+        if not hasattr(self, "track"):
+            raise TrackNotBuilt
         if 'youtube' in self.uri:
             return "https://img.youtube.com/vi/{}/default.jpg".format(self.identifier)
 
         return ""
 
     def __repr__(self):
+        if not hasattr(self, "track"):
+            raise TrackNotBuilt
         return '<AudioTrack title={0.title} identifier={0.identifier}>'.format(self)

--- a/lavalink/Client.py
+++ b/lavalink/Client.py
@@ -4,7 +4,7 @@ from urllib.parse import quote
 
 import aiohttp
 
-from .Events import TrackEndEvent, TrackExceptionEvent, TrackStuckEvent
+from .Events import TrackEndEvent, TrackExceptionEvent, TrackStuckEvent, PlayerStatusUpdate
 from .NodeManager import NodeManager, NoNodesAvailable
 from .PlayerManager import DefaultPlayer
 
@@ -120,6 +120,7 @@ class Client:
                 player = node.players.get(guild_id)
                 player.position = data['state'].get('position', 0)
                 player.position_timestamp = data['state']['time']
+                await self.dispatch_event(PlayerStatusUpdate(player, player.current))
                 break
 
     async def get_tracks(self, query):

--- a/lavalink/Client.py
+++ b/lavalink/Client.py
@@ -61,7 +61,7 @@ class Client:
         self._server_version = 2
         self.nodes = NodeManager(self, default_node, rest_round_robin, player)
 
-        self.bot.loop.create_task(self.garbage_collection())
+        # self.bot.loop.create_task(self.garbage_collection())
 
     def register_hook(self, func):
         """

--- a/lavalink/Client.py
+++ b/lavalink/Client.py
@@ -133,7 +133,7 @@ class Client:
         async with self.http.get(node.rest_uri + quote(query), headers={'Authorization': node.password}) as res:
             return await res.json(content_type=None)
 
-    async def get_player(self, guild_id: int, create: bool=True):
+    async def get_player(self, guild_id: int, create: bool = True):
         try:
             await asyncio.wait_for(self.nodes.ready.wait(), timeout=10.0)
         except asyncio.TimeoutError:
@@ -181,28 +181,26 @@ class Client:
             return
 
         if data['t'] == 'VOICE_SERVER_UPDATE':
+            voice_server_package = {
+                'op': 'voiceUpdate',
+                'guildId': data['d']['guild_id'],
+                'event': data['d']
+            }
             try:
-                self.voice_states[int(data['d']['guild_id'])].update({
-                    'op': 'voiceUpdate',
-                    'guildId': data['d']['guild_id'],
-                    'event': data['d']
-                })
+                self.voice_states[int(data['d']['guild_id'])].update(voice_server_package)
             except KeyError:
-                self.voice_states[int(data['d']['guild_id'])] = {
-                    'op': 'voiceUpdate',
-                    'guildId': data['d']['guild_id'],
-                    'event': data['d']
-                }
+                self.voice_states[int(data['d']['guild_id'])] = voice_server_package
 
             log.debug('Voice server update: {}'.format(str(data)))
         else:
             if int(data['d']['user_id']) != self.bot.user.id:
                 return
 
+            voice_state_package = {'sessionId': data['d']['session_id']}
             try:
-                self.voice_states[int(data['d']['guild_id'])].update({'sessionId': data['d']['session_id']})
+                self.voice_states[int(data['d']['guild_id'])].update(voice_state_package)
             except KeyError:
-                self.voice_states[int(data['d']['guild_id'])] = {'sessionId': data['d']['session_id']}
+                self.voice_states[int(data['d']['guild_id'])] = voice_state_package
 
             guild_id = int(data['d']['guild_id'])
 

--- a/lavalink/Client.py
+++ b/lavalink/Client.py
@@ -136,16 +136,12 @@ class Client:
         except asyncio.TimeoutError:
             raise NoNodesAvailable
         if guild_id in self.players:
-            log.debug('Found player in cache.')
             return self.players[guild_id]
-        log.debug('Player not in cache')
         if not create:
             return None
         guild = self.bot.get_guild(guild_id)
         if guild is None:
-            log.debug('Couldn\'t find the guild.')
             return self.players.get(guild_id, self.nodes.nodes[0])
-        log.debug('Getting new player from geo.')
         return self.nodes.get_by_region(guild)
 
     # Bot Events
@@ -167,7 +163,7 @@ class Client:
         guild_id = int(data['d']['guild_id'])
         player = self.players[guild_id]
         if not player:
-            log.info('Client received an updated for a non-existent player. {}'.format(guild_id))
+            log.debug('Client received an update for a non-existent player. {}'.format(guild_id))
             return
 
         if data['t'] == 'VOICE_SERVER_UPDATE':

--- a/lavalink/Client.py
+++ b/lavalink/Client.py
@@ -133,7 +133,7 @@ class Client:
         async with self.http.get(node.rest_uri + quote(query), headers={'Authorization': node.password}) as res:
             return await res.json(content_type=None)
 
-    async def get_player(self, guild_id: int):
+    async def get_player(self, guild_id: int, no_create: bool=False):
         try:
             await asyncio.wait_for(self.nodes.ready.wait(), timeout=10.0)
         except asyncio.TimeoutError:
@@ -143,6 +143,8 @@ class Client:
                 log.debug('Found player in cache.')
                 return node.players[guild_id]
         log.debug('Player not in cache')
+        if no_create:
+            return None
         guild = self.bot.get_guild(guild_id)
         if guild is None:
             log.debug('Couldn\'t find the guild.')

--- a/lavalink/Client.py
+++ b/lavalink/Client.py
@@ -6,7 +6,7 @@ import aiohttp
 
 from .Events import TrackEndEvent, TrackExceptionEvent, TrackStuckEvent, PlayerStatusUpdate
 from .NodeManager import NodeManager, NoNodesAvailable
-from .PlayerManager import DefaultPlayer
+from .PlayerManager import DefaultPlayer, PlayerManager
 
 log = logging.getLogger(__name__)
 
@@ -47,8 +47,6 @@ class Client:
 
         bot.lavalink = self
         self.http = aiohttp.ClientSession(loop=loop)
-        self.voice_states = {}
-        self.voice_wait_locks = {}
         self.hooks = []
 
         set_log_level(log_level)
@@ -60,6 +58,7 @@ class Client:
         self.new_loop = asyncio.new_event_loop()
         self._server_version = 2
         self.nodes = NodeManager(self, default_node, rest_round_robin, player)
+        self.players = PlayerManager(self, player)
 
     def register_hook(self, func):
         """
@@ -116,13 +115,13 @@ class Client:
         """ Updates a player's state when a payload with opcode ``playerUpdate`` is received. """
         guild_id = int(data['guildId'])
 
-        for node in self.nodes:
-            if guild_id in node.players:
-                player = node.players.get(guild_id)
-                player.position = data['state'].get('position', 0)
-                player.position_timestamp = data['state']['time']
-                await self.dispatch_event(PlayerStatusUpdate(player, player.current))
-                break
+        if guild_id in self.players:
+            player = self.players[guild_id]
+            if not player:
+                return
+            player.position = data['state'].get('position', 0)
+            player.position_timestamp = data['state']['time']
+            await self.dispatch_event(PlayerStatusUpdate(player, player.current))
 
     async def get_tracks(self, query):
         """ Returns a Dictionary containing search results for a given query. """
@@ -136,17 +135,16 @@ class Client:
             await asyncio.wait_for(self.nodes.ready.wait(), timeout=10.0)
         except asyncio.TimeoutError:
             raise NoNodesAvailable
-        for node in self.nodes:
-            if guild_id in node.players:
-                log.debug('Found player in cache.')
-                return node.players[guild_id]
+        if guild_id in self.players:
+            log.debug('Found player in cache.')
+            return self.players[guild_id]
         log.debug('Player not in cache')
         if not create:
             return None
         guild = self.bot.get_guild(guild_id)
         if guild is None:
             log.debug('Couldn\'t find the guild.')
-            return self.nodes.nodes[0].players.get(guild_id)
+            return self.players.get(guild_id, self.nodes.nodes[0])
         log.debug('Getting new player from geo.')
         return self.nodes.get_by_region(guild)
 
@@ -166,47 +164,33 @@ class Client:
         if not data or data.get('t', '') not in ['VOICE_STATE_UPDATE', 'VOICE_SERVER_UPDATE']:
             return
 
+        guild_id = int(data['d']['guild_id'])
+        player = self.players[guild_id]
+        if not player:
+            log.info('Client received an updated for a non-existent player. {}'.format(guild_id))
+            return
+
         if data['t'] == 'VOICE_SERVER_UPDATE':
-            voice_server_package = {
+            player._voice_state.update({
                 'op': 'voiceUpdate',
                 'guildId': data['d']['guild_id'],
                 'event': data['d']
-            }
-            try:
-                self.voice_states[int(data['d']['guild_id'])].update(voice_server_package)
-            except KeyError:
-                self.voice_states[int(data['d']['guild_id'])] = voice_server_package
-
+            })
             log.debug('Voice server update: {}'.format(str(data)))
         else:
             if int(data['d']['user_id']) != self.bot.user.id:
                 return
 
-            voice_state_package = {'sessionId': data['d']['session_id']}
-            try:
-                self.voice_states[int(data['d']['guild_id'])].update(voice_state_package)
-            except KeyError:
-                self.voice_states[int(data['d']['guild_id'])] = voice_state_package
+            player._voice_state.update({'sessionId': data['d']['session_id']})
 
-            guild_id = int(data['d']['guild_id'])
-
-            for node in self.nodes:
-                if node.players[guild_id]:
-                    node.players[guild_id].channel_id = data['d']['channel_id']
-                    break
+            player.channel_id = data['d']['channel_id']
 
             log.debug('Voice state update: {}'.format(str(data)))
 
-        guild_id = int(data['d']['guild_id'])
-        if {'op', 'guildId', 'sessionId', 'event'} == self.voice_states.get(guild_id, {}).keys():
-            log.debug('Sending voice update to lavalink: {}'.format(str(self.voice_states.get(guild_id))))
-            for node in self.nodes:
-                if node.players[guild_id]:
-                    await node.ws.send(**self.voice_states.get(guild_id))
-                    break
-            lock = self.voice_wait_locks.get(guild_id, None)
-            if lock:
-                lock.set()
+        if {'op', 'guildId', 'sessionId', 'event'} == player._voice_state.keys():
+            log.debug('Sending voice update to lavalink: {}'.format(str(player._voice_state)))
+            await player.node.ws.send(**player._voice_state)
+            player._voice_lock.set()
 
     def destroy(self):
         """ Destroys the Lavalink client. """

--- a/lavalink/Client.py
+++ b/lavalink/Client.py
@@ -61,8 +61,6 @@ class Client:
         self._server_version = 2
         self.nodes = NodeManager(self, default_node, rest_round_robin, player)
 
-        # self.bot.loop.create_task(self.garbage_collection())
-
     def register_hook(self, func):
         """
         Registers a hook. Since this probably is a bit difficult, I'll explain it in detail.
@@ -152,18 +150,6 @@ class Client:
         log.debug('Getting new player from geo.')
         return self.nodes.get_by_region(guild)
 
-    async def garbage_collection(self):
-        await self.bot.wait_until_ready()
-        while not self.bot.is_closed():
-            try:
-                for node in self.nodes:
-                    for player in node.players.find_all(lambda x: not x.is_connected):
-                        await node.players.remove(player.guild_id)
-                        self.voice_states.pop(player.guild_id, None)
-            except Exception as e:  # pylint: disable=broad-except
-                log.info('There was an exception during GC: {}'.format(str(e)))
-            await asyncio.sleep(100)
-
     # Bot Events
     async def on_socket_response(self, data):
         """
@@ -209,7 +195,7 @@ class Client:
                     node.players[guild_id].channel_id = data['d']['channel_id']
                     break
 
-            log.debug("Voice state update: {}".format(str(data)))
+            log.debug('Voice state update: {}'.format(str(data)))
 
         guild_id = int(data['d']['guild_id'])
         if {'op', 'guildId', 'sessionId', 'event'} == self.voice_states.get(guild_id, {}).keys():

--- a/lavalink/Client.py
+++ b/lavalink/Client.py
@@ -133,7 +133,7 @@ class Client:
         async with self.http.get(node.rest_uri + quote(query), headers={'Authorization': node.password}) as res:
             return await res.json(content_type=None)
 
-    async def get_player(self, guild_id: int, no_create: bool=False):
+    async def get_player(self, guild_id: int, create: bool=True):
         try:
             await asyncio.wait_for(self.nodes.ready.wait(), timeout=10.0)
         except asyncio.TimeoutError:
@@ -143,7 +143,7 @@ class Client:
                 log.debug('Found player in cache.')
                 return node.players[guild_id]
         log.debug('Player not in cache')
-        if no_create:
+        if not create:
             return None
         guild = self.bot.get_guild(guild_id)
         if guild is None:

--- a/lavalink/Events.py
+++ b/lavalink/Events.py
@@ -40,6 +40,14 @@ class TrackStartEvent:
         self.track = track
 
 
+class PlayerStatusUpdate:
+    """ This event is dispatched every time when lavalink sends a player update. """
+
+    def __init__(self, player, track):
+        self.player = player
+        self.track = track
+
+
 class StatsUpdateEvent:
     """ This event will be dispatched when the websocket receives a statistics update. """
 

--- a/lavalink/Events.py
+++ b/lavalink/Events.py
@@ -48,6 +48,16 @@ class PlayerStatusUpdate:
         self.track = track
 
 
+class WebSocketClosedEvent:
+    """ This event is dispatched every time when lavalink get disconnected from the discord WS. """
+
+    def __init__(self, player, code, reason, by_remote):
+        self.player = player
+        self.code = code
+        self.reason = reason
+        self.by_remote = by_remote
+
+
 class StatsUpdateEvent:
     """ This event will be dispatched when the websocket receives a statistics update. """
 

--- a/lavalink/Events.py
+++ b/lavalink/Events.py
@@ -48,7 +48,7 @@ class PlayerStatusUpdate:
         self.track = track
 
 
-class WebSocketClosedEvent:
+class VoiceWebSocketClosedEvent:
     """ This event is dispatched every time when lavalink get disconnected from the discord WS. """
 
     def __init__(self, player, code, reason, by_remote):

--- a/lavalink/Events.py
+++ b/lavalink/Events.py
@@ -49,7 +49,7 @@ class PlayerStatusUpdate:
 
 
 class VoiceWebSocketClosedEvent:
-    """ This event is dispatched every time when lavalink get disconnected from the discord WS. """
+    """ This event is dispatched every time Lavalink is disconnected from the Discord WS. """
 
     def __init__(self, player, code, reason, by_remote):
         self.player = player

--- a/lavalink/Events.py
+++ b/lavalink/Events.py
@@ -53,7 +53,7 @@ class WebSocketClosedEvent:
 
     def __init__(self, player, code, reason, by_remote):
         self.player = player
-        self.code = code
+        self.code = int(code)
         self.reason = reason
         self.by_remote = by_remote
 

--- a/lavalink/PlayerManager.py
+++ b/lavalink/PlayerManager.py
@@ -93,15 +93,15 @@ class DefaultPlayer(BasePlayer):
 
     def add(self, requester: int, track: dict):
         """ Adds a track to the queue. """
-        self.queue.append(AudioTrack().build(track, requester))
+        self.queue.append(AudioTrack.build(track, requester))
 
     def add_next(self, requester: int, track: dict):
         """ Adds a track to beginning of the queue """
-        self.queue.insert(0, AudioTrack().build(track, requester))
+        self.queue.insert(0, AudioTrack.build(track, requester))
 
     def add_at(self, index: int, requester: int, track: dict):
         """ Adds a track at a specific index in the queue. """
-        self.queue.insert(min(index, len(self.queue) - 1), AudioTrack().build(track, requester))
+        self.queue.insert(min(index, len(self.queue) - 1), AudioTrack.build(track, requester))
 
     async def play(self, track_index: int = 0, ignore_shuffle: bool = False):
         """ Plays the first track in the queue, if any or plays a track from the specified index in the queue. """
@@ -239,4 +239,6 @@ class PlayerManager:
 
     def clear(self):
         """ Removes all of the players from the cache. """
+        for guild_id in self._players:
+            self.lavalink.voice_states.pop(int(guild_id), None)
         self._players.clear()

--- a/lavalink/WebSocket.py
+++ b/lavalink/WebSocket.py
@@ -154,6 +154,8 @@ class WebSocket:
                     event = TrackStuckEvent(player, data['track'], data['thresholdMs'])
                 elif data['type'] == 'WebSocketClosedEvent':
                     event = WebSocketClosedEvent(player, data['code'], data['reason'], data['byRemote'])
+                    if event.code == 4006:
+                        self._lavalink.loop.create_task(player.ws_reset_handler())
 
                 if event is not None:
                     await self._lavalink.dispatch_event(event)

--- a/lavalink/WebSocket.py
+++ b/lavalink/WebSocket.py
@@ -118,13 +118,13 @@ class WebSocket:
                 log.warning('Disconnected from Lavalink: {}'.format(str(error)))
                 self._node.set_offline()
                 if not self._node.manager.nodes:
-                    for g in self._node.players._players.copy().keys():
+                    for g in self._lavalink.players._players.copy().keys():
                         ws = self._lavalink.bot._connection._get_websocket(int(g))
                         await ws.voice_state(int(g), None)
                 else:
                     await self._node.manage_failover()
 
-                self._node.players.clear()
+                self._lavalink.players.clear()
 
                 if self._shutdown:
                     break
@@ -143,7 +143,7 @@ class WebSocket:
 
             if op == 'event':
                 log.debug('Received event of type {}'.format(data['type']))
-                player = self._node.players[int(data['guildId'])]
+                player = self._lavalink.players[int(data['guildId'])]
                 event = None
 
                 if data['type'] == 'TrackEndEvent':
@@ -163,7 +163,7 @@ class WebSocket:
                 await self._lavalink.update_state(data)
             elif op == 'stats':
                 self._node.stats._update(data)
-                await self._node._lavalink.dispatch_event(StatsUpdateEvent(self._node))
+                await self._lavalink.dispatch_event(StatsUpdateEvent(self._node))
 
         log.debug('Closing WebSocket...')
         await self._ws.close()

--- a/lavalink/WebSocket.py
+++ b/lavalink/WebSocket.py
@@ -4,7 +4,7 @@ import logging
 
 import websockets
 
-from .Events import TrackStuckEvent, TrackExceptionEvent, TrackEndEvent, StatsUpdateEvent, WebSocketClosedEvent
+from .Events import TrackStuckEvent, TrackExceptionEvent, TrackEndEvent, StatsUpdateEvent, VoiceWebSocketClosedEvent
 
 log = logging.getLogger(__name__)
 
@@ -153,7 +153,7 @@ class WebSocket:
                 elif data['type'] == 'TrackStuckEvent':
                     event = TrackStuckEvent(player, data['track'], data['thresholdMs'])
                 elif data['type'] == 'WebSocketClosedEvent':
-                    event = WebSocketClosedEvent(player, data['code'], data['reason'], data['byRemote'])
+                    event = VoiceWebSocketClosedEvent(player, data['code'], data['reason'], data['byRemote'])
                     if event.code == 4006:
                         self._lavalink.loop.create_task(player.ws_reset_handler())
 


### PR DESCRIPTION
### Changes:

- Added `PlayerStatusUpdateEvent` sent every time lavalink sends an update. Possible use (well I'm using it) if someone were to make a web player, it's nice to have an update event to send to a web player WebSocket.
- Made `AudioTrack` more pythonic, removed that nasty `()` from building, now it's `AudioTrack.build(...)`
- Made ll.py compatible with lavalink server v3.1, by first trying to connect to a `rest_port`, if it fails, try `ws_port` if even that fails, throw an error (as previously).
- Added `WebSocketClosedEvent` for v3.1 compatibility, I don't know what else to do with it, because I haven't encountered it in the wild yet.
- Improved `manage_failover`, so we don't have to disconnect and then re-connect. Handover is now smooth AF.
- Added some magic and pixie dust to `on_socket_response`, so changes to voice WebSockets are auto-magically resolved. Jokes aside, I've added a dictionary that stores full voice event updates and state changes, on the guild by guild basis.
- Added garbage collection system, to collect some unused stuff, you don't want that stuff pilling up.

***BIG BOYE PYLINT:*** *[click here, **CLICK IT**](https://paste.ubuntu.com/p/FdkfGMxVYh/)*