### PR TITLE
Event Hook Decorators, Better AudioTrack, EQ & Copyright Year Fix, + more

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Luke & William
+Copyright (c) 2019 Luke & William
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/examples/music.py
+++ b/examples/music.py
@@ -21,7 +21,7 @@ class Music(commands.Cog):
             bot.lavalink.add_node('127.0.0.1', 2333, 'youshallnotpass', 'eu', 'default-node')  # Host, Port, Password, Region, Name
             bot.add_listener(bot.lavalink.voice_update_handler, 'on_socket_response')
 
-        bot.lavalink.add_event_hook(self.track_hook)
+        lavalink.add_event_hook(self.track_hook)
 
     def cog_unload(self):
         self.bot.lavalink._event_hooks.clear()
@@ -50,6 +50,11 @@ class Music(commands.Cog):
             guild_id = int(event.player.guild_id)
             await self.connect_to(guild_id, None)
             # Disconnect from the channel -- there's nothing else to play.
+
+    # You can create event hooks by decorators too.
+    @lavalink.on(lavalink.events.TrackStartEvent)
+    async def on_track_start(self, event):
+        print('{} has just started playing!'.format(event.track.title))
 
     async def connect_to(self, guild_id: int, channel_id: str):
         """ Connects to the given voicechannel ID. A channel_id of `None` means disconnect. """
@@ -87,6 +92,9 @@ class Music(commands.Cog):
             track = results['tracks'][0]
             embed.title = 'Track Enqueued'
             embed.description = f'[{track["info"]["title"]}]({track["info"]["uri"]})'
+
+            # You can create your own AudioTrack and add more information about the track you may want.
+            track = lavalink.models.AudioTrack.build(track, ctx.author.id, {'Recommended': True})
             player.add(requester=ctx.author.id, track=track)
 
         await ctx.send(embed=embed)

--- a/examples/music.py
+++ b/examples/music.py
@@ -24,7 +24,7 @@ class Music(commands.Cog):
         lavalink.add_event_hook(self.track_hook)
 
     def cog_unload(self):
-        self.bot.lavalink._event_hooks.clear()
+        self.bot.lavalink.client_event_hooks.clear()
 
     async def cog_before_invoke(self, ctx):
         guild_check = ctx.guild is not None

--- a/examples/music.py
+++ b/examples/music.py
@@ -66,7 +66,7 @@ class Music(commands.Cog):
     @commands.command(aliases=['p'])
     async def play(self, ctx, *, query: str):
         """ Searches and plays a song from a given query. """
-        player = self.bot.lavalink.players.get(ctx.guild.id)
+        player = self.bot.lavalink.player_manager.get(ctx.guild.id)
 
         query = query.strip('<>')
 
@@ -105,7 +105,7 @@ class Music(commands.Cog):
     @commands.command()
     async def seek(self, ctx, *, seconds: int):
         """ Seeks to a given position in a track. """
-        player = self.bot.lavalink.players.get(ctx.guild.id)
+        player = self.bot.lavalink.player_manager.get(ctx.guild.id)
 
         track_time = player.position + (seconds * 1000)
         await player.seek(track_time)
@@ -115,7 +115,7 @@ class Music(commands.Cog):
     @commands.command(aliases=['forceskip'])
     async def skip(self, ctx):
         """ Skips the current track. """
-        player = self.bot.lavalink.players.get(ctx.guild.id)
+        player = self.bot.lavalink.player_manager.get(ctx.guild.id)
 
         if not player.is_playing:
             return await ctx.send('Not playing.')
@@ -126,7 +126,7 @@ class Music(commands.Cog):
     @commands.command()
     async def stop(self, ctx):
         """ Stops the player and clears its queue. """
-        player = self.bot.lavalink.players.get(ctx.guild.id)
+        player = self.bot.lavalink.player_manager.get(ctx.guild.id)
 
         if not player.is_playing:
             return await ctx.send('Not playing.')
@@ -138,7 +138,7 @@ class Music(commands.Cog):
     @commands.command(aliases=['np', 'n', 'playing'])
     async def now(self, ctx):
         """ Shows some stats about the currently playing song. """
-        player = self.bot.lavalink.players.get(ctx.guild.id)
+        player = self.bot.lavalink.player_manager.get(ctx.guild.id)
 
         if not player.current:
             return await ctx.send('Nothing playing.')
@@ -157,7 +157,7 @@ class Music(commands.Cog):
     @commands.command(aliases=['q'])
     async def queue(self, ctx, page: int = 1):
         """ Shows the player's queue. """
-        player = self.bot.lavalink.players.get(ctx.guild.id)
+        player = self.bot.lavalink.player_manager.get(ctx.guild.id)
 
         if not player.queue:
             return await ctx.send('Nothing queued.')
@@ -180,7 +180,7 @@ class Music(commands.Cog):
     @commands.command(aliases=['resume'])
     async def pause(self, ctx):
         """ Pauses/Resumes the current track. """
-        player = self.bot.lavalink.players.get(ctx.guild.id)
+        player = self.bot.lavalink.player_manager.get(ctx.guild.id)
 
         if not player.is_playing:
             return await ctx.send('Not playing.')
@@ -195,7 +195,7 @@ class Music(commands.Cog):
     @commands.command(aliases=['vol'])
     async def volume(self, ctx, volume: int = None):
         """ Changes the player's volume (0-1000). """
-        player = self.bot.lavalink.players.get(ctx.guild.id)
+        player = self.bot.lavalink.player_manager.get(ctx.guild.id)
 
         if not volume:
             return await ctx.send(f'🔈 | {player.volume}%')
@@ -206,7 +206,7 @@ class Music(commands.Cog):
     @commands.command()
     async def shuffle(self, ctx):
         """ Shuffles the player's queue. """
-        player = self.bot.lavalink.players.get(ctx.guild.id)
+        player = self.bot.lavalink.player_manager.get(ctx.guild.id)
         if not player.is_playing:
             return await ctx.send('Nothing playing.')
 
@@ -216,7 +216,7 @@ class Music(commands.Cog):
     @commands.command(aliases=['loop'])
     async def repeat(self, ctx):
         """ Repeats the current song until the command is invoked again. """
-        player = self.bot.lavalink.players.get(ctx.guild.id)
+        player = self.bot.lavalink.player_manager.get(ctx.guild.id)
 
         if not player.is_playing:
             return await ctx.send('Nothing playing.')
@@ -227,7 +227,7 @@ class Music(commands.Cog):
     @commands.command()
     async def remove(self, ctx, index: int):
         """ Removes an item from the player's queue with the given index. """
-        player = self.bot.lavalink.players.get(ctx.guild.id)
+        player = self.bot.lavalink.player_manager.get(ctx.guild.id)
 
         if not player.queue:
             return await ctx.send('Nothing queued.')
@@ -242,7 +242,7 @@ class Music(commands.Cog):
     @commands.command()
     async def find(self, ctx, *, query):
         """ Lists the first 10 search results from a given query. """
-        player = self.bot.lavalink.players.get(ctx.guild.id)
+        player = self.bot.lavalink.player_manager.get(ctx.guild.id)
 
         if not query.startswith('ytsearch:') and not query.startswith('scsearch:'):
             query = 'ytsearch:' + query
@@ -266,7 +266,7 @@ class Music(commands.Cog):
     @commands.command(aliases=['dc'])
     async def disconnect(self, ctx):
         """ Disconnects the player from the voice channel and clears its queue. """
-        player = self.bot.lavalink.players.get(ctx.guild.id)
+        player = self.bot.lavalink.player_manager.get(ctx.guild.id)
 
         if not player.is_connected:
             return await ctx.send('Not connected.')
@@ -281,7 +281,7 @@ class Music(commands.Cog):
 
     async def ensure_voice(self, ctx):
         """ This check ensures that the bot and command author are in the same voicechannel. """
-        player = self.bot.lavalink.players.create(ctx.guild.id, endpoint=str(ctx.guild.region))
+        player = self.bot.lavalink.player_manager.create(ctx.guild.id, endpoint=str(ctx.guild.region))
         # Create returns a player if one exists, otherwise creates.
 
         should_connect = ctx.command.name in ('play')  # Add commands that require joining voice to work.

--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -3,7 +3,7 @@
 __title__ = 'Lavalink'
 __author__ = 'Devoxin'
 __license__ = 'MIT'
-__copyright__ = 'Copyright 2018 Devoxin'
+__copyright__ = 'Copyright 2019 Devoxin'
 __version__ = '3.0.0'
 
 

--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -9,16 +9,14 @@ __version__ = '3.0.0'
 
 import logging
 import sys
-from .client import Client
+from .client import Client, _event_hooks
 from .events import Event, TrackStartEvent, TrackStuckEvent, TrackExceptionEvent, TrackEndEvent, QueueEndEvent
 from .models import BasePlayer, DefaultPlayer, AudioTrack, NoPreviousTrack, InvalidTrack
 from .node import Node
 from .nodemanager import NodeManager
 from .playermanager import PlayerManager
-from .utils import format_time
+from .utils import format_time, parse_time
 from .websocket import WebSocket
-
-_event_hooks = {}
 
 
 def enable_debug_logging():

--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -60,7 +60,7 @@ def add_event_hook(hook, event: Event = None):
             _event_hooks[event or 'Generic'].append(hook)
 
 
-def on(event: Event = 'Generic'):
+def on(event: Event = None):
     """
     Adds an event hook when decorated with a function.
 

--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -10,13 +10,15 @@ __version__ = '3.0.0'
 import logging
 import sys
 from .client import Client
-from .events import TrackStartEvent, TrackStuckEvent, TrackExceptionEvent, TrackEndEvent, QueueEndEvent
+from .events import Event, TrackStartEvent, TrackStuckEvent, TrackExceptionEvent, TrackEndEvent, QueueEndEvent
 from .models import BasePlayer, DefaultPlayer, AudioTrack, NoPreviousTrack, InvalidTrack
 from .node import Node
 from .nodemanager import NodeManager
 from .playermanager import PlayerManager
 from .utils import format_time
 from .websocket import WebSocket
+
+_internal_event_hooks = {}
 
 
 def enable_debug_logging():
@@ -36,3 +38,39 @@ def enable_debug_logging():
     log.addHandler(handler)
 
     log.setLevel(logging.DEBUG)
+
+
+def _internal_add_event_hook(hook, event: Event = None):
+    """
+    Adds an event hook to be dispatched on an event.
+    ----------
+    :param hook:
+        The hook to be added, that will be dispatched when an event is dispatched.
+        If `event` parameter is left empty, then it will run when any event is dispatched.
+    :param event:
+        The event the hook belongs to. This will dispatch when that specific event is
+        dispatched.
+    """
+    event_hooks = _internal_event_hooks.get(event)
+
+    if hook not in event_hooks:
+        if not event_hooks:
+            _internal_event_hooks['Generic'] = [hook]
+        else:
+            _internal_event_hooks[event].append(hook)
+
+
+def on(event: Event = 'Generic'):
+    """
+    Adds an event hook when decorated with a function.
+
+    Parameters
+    ----------
+    event: Event
+        The event that will dispatch the given event hook. This defaults
+        to 'Generic', which is dispatched on all events.
+    """
+    def decorator(func):
+        _internal_add_event_hook(func, event)
+
+    return decorator

--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -45,11 +45,13 @@ def enable_debug_logging():
 def add_event_hook(hook, event: Event = None):
     """
     Adds an event hook to be dispatched on an event.
+
+    Parameters
     ----------
-    :param hook:
+    hook: function
         The hook to register for the given event type.
         If `event` parameter is left empty, then it will run when any event is dispatched.
-    :param event:
+    event: Event
         The event the hook belongs to. This will dispatch when that specific event is
         dispatched.
     """

--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -11,11 +11,14 @@ import logging
 import sys
 import inspect
 from .client import Client, _event_hooks
-from .events import Event, TrackStartEvent, TrackStuckEvent, TrackExceptionEvent, TrackEndEvent, QueueEndEvent
+from .events import Event, TrackStartEvent, TrackStuckEvent, TrackExceptionEvent, TrackEndEvent, QueueEndEvent, \
+    NodeConnectedEvent, NodeChangedEvent, NodeDisconnectedEvent, WebSocketClosedEvent
+from .exceptions import NodeException
 from .models import BasePlayer, DefaultPlayer, AudioTrack, NoPreviousTrack, InvalidTrack
 from .node import Node
 from .nodemanager import NodeManager
 from .playermanager import PlayerManager
+from .stats import Penalty, Stats
 from .utils import format_time, parse_time
 from .websocket import WebSocket
 

--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -51,13 +51,13 @@ def add_event_hook(hook, event: Event = None):
         The event the hook belongs to. This will dispatch when that specific event is
         dispatched.
     """
-    event_hooks = _event_hooks.get(event)
+    event_hooks = _event_hooks.get(event, [])
 
     if hook not in event_hooks:
         if not event_hooks:
-            _event_hooks['Generic'] = [hook]
+            _event_hooks[event or 'Generic'] = list(hook)
         else:
-            _event_hooks[event].append(hook)
+            _event_hooks[event or 'Generic'].append(hook)
 
 
 def on(event: Event = 'Generic'):

--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -40,7 +40,7 @@ def enable_debug_logging():
     log.setLevel(logging.DEBUG)
 
 
-def _internal_add_event_hook(hook, event: Event = None):
+def add_event_hook(hook, event: Event = None):
     """
     Adds an event hook to be dispatched on an event.
     ----------

--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -50,17 +50,17 @@ def add_event_hook(hook, event: Event = None):
         The event the hook belongs to. This will dispatch when that specific event is
         dispatched.
     """
-    if event is not None or not isinstance(event, Event):
+    if event is not None and not isinstance(event, Event):
         raise TypeError('Event parameter is not of type Event or None')
 
-    if not callable(hook) or inspect.iscoroutinefunction(hook):
+    if not callable(hook) or not inspect.iscoroutinefunction(hook):
         raise TypeError('Hook is not callable or a coroutine')
 
     event_hooks = _event_hooks.get(event, [])
 
     if hook not in event_hooks:
         if not event_hooks:
-            _event_hooks[event or 'Generic'] = list(hook)
+            _event_hooks[event or 'Generic'] = [hook]
         else:
             _event_hooks[event or 'Generic'].append(hook)
 

--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -8,19 +8,20 @@ __version__ = '3.0.0'
 
 
 import logging
-import sys
 import inspect
-from .client import Client, _event_hooks
+import sys
+
 from .events import Event, TrackStartEvent, TrackStuckEvent, TrackExceptionEvent, TrackEndEvent, QueueEndEvent, \
     NodeConnectedEvent, NodeChangedEvent, NodeDisconnectedEvent, WebSocketClosedEvent
-from .exceptions import NodeException
 from .models import BasePlayer, DefaultPlayer, AudioTrack, NoPreviousTrack, InvalidTrack
-from .node import Node
-from .nodemanager import NodeManager
-from .playermanager import PlayerManager
-from .stats import Penalty, Stats
 from .utils import format_time, parse_time
+from .client import Client, _event_hooks
+from .playermanager import PlayerManager
+from .exceptions import NodeException
+from .nodemanager import NodeManager
+from .stats import Penalty, Stats
 from .websocket import WebSocket
+from .node import Node
 
 
 def enable_debug_logging():
@@ -42,14 +43,14 @@ def enable_debug_logging():
     log.setLevel(logging.DEBUG)
 
 
-def add_event_hook(hook, event: Event = None):
+def add_event_hook(*hooks, event: Event = None):
     """
     Adds an event hook to be dispatched on an event.
 
     Parameters
     ----------
-    hook: function
-        The hook to register for the given event type.
+    hooks: function
+        The hooks to register for the given event type.
         If `event` parameter is left empty, then it will run when any event is dispatched.
     event: Event
         The event the hook belongs to. This will dispatch when that specific event is
@@ -58,16 +59,17 @@ def add_event_hook(hook, event: Event = None):
     if event is not None and not isinstance(event, Event):
         raise TypeError('Event parameter is not of type Event or None')
 
-    if not callable(hook) or not inspect.iscoroutinefunction(hook):
-        raise TypeError('Hook is not callable or a coroutine')
-
     event_hooks = _event_hooks.get(event, [])
 
-    if hook not in event_hooks:
-        if not event_hooks:
-            _event_hooks[event or 'Generic'] = [hook]
-        else:
-            _event_hooks[event or 'Generic'].append(hook)
+    for hook in hooks:
+        if not callable(hook) or not inspect.iscoroutinefunction(hook):
+            raise TypeError('Hook is not callable or a coroutine')
+
+        if hook not in event_hooks:
+            if not event_hooks:
+                _event_hooks[event or 'Generic'] = [hook]
+            else:
+                _event_hooks[event or 'Generic'].append(hook)
 
 
 def on(event: Event = None):

--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -24,7 +24,7 @@ def enable_debug_logging():
     Sets up a logger to stdout. This solely exists to make things easier for
     end-users who want to debug issues with Lavalink.py.
     """
-    log = logging.getLogger(__name__)
+    log = logging.getLogger('lavalink')
 
     fmt = logging.Formatter(
         '[%(asctime)s] [lavalink.py] [%(levelname)s] %(message)s',

--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -9,6 +9,7 @@ __version__ = '3.0.0'
 
 import logging
 import sys
+import inspect
 from .client import Client, _event_hooks
 from .events import Event, TrackStartEvent, TrackStuckEvent, TrackExceptionEvent, TrackEndEvent, QueueEndEvent
 from .models import BasePlayer, DefaultPlayer, AudioTrack, NoPreviousTrack, InvalidTrack
@@ -49,6 +50,12 @@ def add_event_hook(hook, event: Event = None):
         The event the hook belongs to. This will dispatch when that specific event is
         dispatched.
     """
+    if event is not None or not isinstance(event, Event):
+        raise TypeError('Event parameter is not of type Event or None')
+
+    if not callable(hook) or inspect.iscoroutinefunction(hook):
+        raise TypeError('Hook is not callable or a coroutine')
+
     event_hooks = _event_hooks.get(event, [])
 
     if hook not in event_hooks:

--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -18,7 +18,7 @@ from .playermanager import PlayerManager
 from .utils import format_time
 from .websocket import WebSocket
 
-_internal_event_hooks = {}
+_event_hooks = {}
 
 
 def enable_debug_logging():
@@ -45,19 +45,19 @@ def add_event_hook(hook, event: Event = None):
     Adds an event hook to be dispatched on an event.
     ----------
     :param hook:
-        The hook to be added, that will be dispatched when an event is dispatched.
+        The hook to register for the given event type.
         If `event` parameter is left empty, then it will run when any event is dispatched.
     :param event:
         The event the hook belongs to. This will dispatch when that specific event is
         dispatched.
     """
-    event_hooks = _internal_event_hooks.get(event)
+    event_hooks = _event_hooks.get(event)
 
     if hook not in event_hooks:
         if not event_hooks:
-            _internal_event_hooks['Generic'] = [hook]
+            _event_hooks['Generic'] = [hook]
         else:
-            _internal_event_hooks[event].append(hook)
+            _event_hooks[event].append(hook)
 
 
 def on(event: Event = 'Generic'):
@@ -71,6 +71,6 @@ def on(event: Event = 'Generic'):
         to 'Generic', which is dispatched on all events.
     """
     def decorator(func):
-        _internal_add_event_hook(func, event)
+        add_event_hook(func, event)
 
     return decorator

--- a/lavalink/client.py
+++ b/lavalink/client.py
@@ -59,11 +59,12 @@ class Client:
         )  # This session will be used for websocket and http requests.
 
     def add_event_hook(self, hook):
-        if hook not in self._event_hooks.get("Unknown Event"):
-            if self._event_hooks.get("Unknown Event") is None:
-                self._event_hooks["Unknown Event"] = [hook]
+        event_hooks = self._event_hooks.get('Unknown Event')
+        if hook not in event_hooks:
+            if event_hooks is None:
+                self._event_hooks['Unknown Event'] = [hook]
             else:
-                self._event_hooks["Unknown Event"].append(hook)
+                self._event_hooks['Unknown Event'].append(hook)
 
     def add_node(self, host: str, port: int, password: str, region: str,
                  resume_key: str = None, resume_timeout: int = 60, name: str = None):
@@ -220,7 +221,7 @@ class Client:
             The event to dispatch to the hooks.
         """
         try:
-            unknown_events = self._event_hooks.get("Unknown Events")
+            unknown_events = self._event_hooks.get('Unknown Events')
             registered_events = self._event_hooks.get(event)
 
             event_hooks = unknown_events + registered_events

--- a/lavalink/client.py
+++ b/lavalink/client.py
@@ -212,12 +212,7 @@ class Client:
 
     def on(self, event: Event):
         def decorator(func):
-            event_hook = self._event_hooks.get(event)
-
-            if event_hook is None:
-                self._event_hooks[event] = [func]
-            else:
-                event_hook.append(func)
+            self.add_event_hook(func, event)
 
         return decorator
 

--- a/lavalink/client.py
+++ b/lavalink/client.py
@@ -229,11 +229,12 @@ class Client:
         registered_events = self._event_hooks.get(event) or []
 
         try:
-            async for generic_hook in generic_events:
-                await generic_hook(event)
-                async for registered_hook in registered_events:
-                    await registered_hook(event)
+            async for hook in generic_events:
+                await hook(event)
 
-            self.logger.info('Dispatched {} event to all registered hooks'.format(event.__name__))
+            async for hook in registered_events:
+                await hook(event)
+
+            self._logger.info('Dispatched {} event to all registered hooks'.format(event.__name__))
         except Exception as e:  # pylint: disable=W0703
-            self.logger.warning('Event hook {} encountered an exception!'.format(hook.__name__), e)
+            self._logger.warning('Event hook {} encountered an exception!'.format(hook.__name__), e)

--- a/lavalink/client.py
+++ b/lavalink/client.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 import random
-import inspect
 from urllib.parse import quote
 
 import aiohttp

--- a/lavalink/client.py
+++ b/lavalink/client.py
@@ -61,33 +61,41 @@ class Client:
                  resume_key: str = None, resume_timeout: int = 60, name: str = None):
         """
         Adds a node to Lavalink's node manager.
+
+        Parameters
         ----------
-        :param host:
+        host: str
             The address of the Lavalink node.
-        :param port:
+        port: int
             The port to use for websocket and REST connections.
-        :param password:
+        password: str
             The password used for authentication.
-        :param region:
+        region: str
             The region to assign this node to.
-        :param resume_key:
+        resume_key: Optional[str]
             A resume key used for resuming a session upon re-establishing a WebSocket connection to Lavalink.
-        :param resume_timeout:
+        resume_timeout: Optional[int]
             How long the node should wait for a connection while disconnected before clearing all players.
-        :param name:
+        name: Optional[str]
             An identifier for the node that will show in logs.
         """
-        self.node_manager.add_node(host, port, password, region, name, resume_key, resume_timeout)
+        self.node_manager.add_node(host, port, password, region, resume_key, resume_timeout, name)
 
     async def get_tracks(self, query: str, node: Node = None):
         """|coro|
 
         Gets all tracks associated with the given query.
-        -----------------
-        :param query:
+
+        Parameters
+        ----------
+        query: str
             The query to perform a search for.
-        :param node:
+        node: Optional[Node]
             The node to use for track lookup. Leave this blank to use a random node.
+
+        Returns
+        ----------
+        A dict representing tracks.
         """
         node = node or random.choice(self.node_manager.available_nodes)
         destination = 'http://{}:{}/loadtracks?identifier={}'.format(node.host, node.port, quote(query))
@@ -110,7 +118,7 @@ class Client:
         ----------
         track: str
             The base64-encoded `track` string.
-        node: Node
+        node: Optional[Node]
             The node to use for the query. ``None`` means random.
 
         Returns
@@ -138,7 +146,7 @@ class Client:
         ----------
         tracks: list[str]
             A list of base64-encoded `track` strings.
-        node: Node
+        node: Optional[Node]
             The node to use for the query. ``None`` means random.
 
         Returns
@@ -164,11 +172,14 @@ class Client:
         forwards the relevant information on to Lavalink, which is used to
         establish a websocket connection and send audio packets to Discord.
 
-        -------------
-        :example:
-            bot.add_listener(lavalink_client.voice_update_handler, 'on_socket_response')
+        Example
+        ----------
+        ```bot.add_listener(lavalink_client.voice_update_handler,
+                            'on_socket_response')```
 
-        :param data:
+        Parameters
+        ----------
+        data: dict
             The payload received from Discord.
         """
         if not data or 't' not in data:
@@ -196,8 +207,10 @@ class Client:
         """|coro|
 
         Dispatches the given event to all registered hooks.
+
+        Parameters
         ----------
-        :param event:
+        event: Event
             The event to dispatch to the hooks.
         """
         generic_hooks = _event_hooks.get('Generic', [])

--- a/lavalink/client.py
+++ b/lavalink/client.py
@@ -211,7 +211,19 @@ class Client:
         else:
             return
 
-    def on(self, event: Event):
+    def on(self, event: Event = "Generic"):
+        """
+        Adds an event hook when decorated with a function.
+
+        Parameters
+        ----------
+        event: Event
+            The event that will dispatch the given event hook.
+
+        Returns
+        ---------
+        None
+        """
         def decorator(func):
             self.add_event_hook(func, event)
 

--- a/lavalink/client.py
+++ b/lavalink/client.py
@@ -229,12 +229,12 @@ class Client:
         :param event:
             The event to dispatch to the hooks.
         """
+        unknown_events = self._event_hooks.get(None) or []
+        registered_events = self._event_hooks.get(event) or []
+
+        event_hooks = unknown_events + registered_events
+
         try:
-            unknown_events = self._event_hooks.get(None)
-            registered_events = self._event_hooks.get(event)
-
-            event_hooks = unknown_events + registered_events
-
             for hook in event_hooks:
                 if inspect.iscoroutinefunction(hook):
                     await hook(event)

--- a/lavalink/client.py
+++ b/lavalink/client.py
@@ -60,7 +60,8 @@ class Client:
 
     def add_event_hook(self, hook, event: Event = None):
         """
-
+        Adds an event hook to be dispatched on an event.
+        ----------
         :param hook:
             The hook to be added, that will be dispatched when an event is dispatched.
             If `event` parameter is left empty, then it will run when any event is dispatched.

--- a/lavalink/client.py
+++ b/lavalink/client.py
@@ -224,7 +224,7 @@ class Client:
         :param event:
             The event to dispatch to the hooks.
         """
-        generic_events = self._event_hooks.get("Generic") or []
+        generic_events = self._event_hooks.get('Generic') or []
         registered_events = self._event_hooks.get(event) or []
 
         try:

--- a/lavalink/client.py
+++ b/lavalink/client.py
@@ -12,8 +12,6 @@ from .nodemanager import NodeManager
 from .playermanager import PlayerManager
 from .events import Event
 
-log = logging.getLogger('lavalink')
-
 
 class Client:
     """
@@ -50,6 +48,7 @@ class Client:
         self._loop = loop or asyncio.get_event_loop()
         self.node_manager = NodeManager(self, regions)
         self.players = PlayerManager(self, player)
+        self.logger = logging.getLogger(__name__)
 
         self._event_hooks = {}
 
@@ -242,6 +241,6 @@ class Client:
                 else:
                     hook(event)
 
-            log.info('Dispatched {} event to all registered hooks'.format(event.__name__))
+            self.logger.info('Dispatched {} event to all registered hooks'.format(event.__name__))
         except Exception as e:  # pylint: disable=W0703
-            log.warning('Event hook {} encountered an exception!'.format(hook.__name__), e)
+            self.logger.warning('Event hook {} encountered an exception!'.format(hook.__name__), e)

--- a/lavalink/client.py
+++ b/lavalink/client.py
@@ -48,7 +48,7 @@ class Client:
         self._loop = loop or asyncio.get_event_loop()
         self.node_manager = NodeManager(self, regions)
         self.players = PlayerManager(self, player)
-        self.logger = logging.getLogger(__name__)
+        self._logger = logging.getLogger('lavalink')
 
         self._event_hooks = {}
 

--- a/lavalink/client.py
+++ b/lavalink/client.py
@@ -6,7 +6,7 @@ from urllib.parse import quote
 
 import aiohttp
 
-from . import _internal_event_hooks
+from . import _event_hooks
 from .models import DefaultPlayer
 from .node import Node
 from .nodemanager import NodeManager
@@ -48,7 +48,7 @@ class Client:
         self._shard_count = str(shard_count)
         self._loop = loop or asyncio.get_event_loop()
         self.node_manager = NodeManager(self, regions)
-        self.players = PlayerManager(self, player)
+        self.player_manager = PlayerManager(self, player)
         self._logger = logging.getLogger('lavalink')
 
         self._session = aiohttp.ClientSession(
@@ -199,8 +199,8 @@ class Client:
         :param event:
             The event to dispatch to the hooks.
         """
-        generic_hooks = _internal_event_hooks.get('Generic', [])
-        targeted_hooks = _internal_event_hooks.get(event, [])
+        generic_hooks = _event_hooks.get('Generic', [])
+        targeted_hooks = _event_hooks.get(event, [])
 
         tasks = [hook(event) for hook in itertools.chain(generic_hooks, targeted_hooks)]
 

--- a/lavalink/client.py
+++ b/lavalink/client.py
@@ -6,12 +6,13 @@ from urllib.parse import quote
 
 import aiohttp
 
-from . import _event_hooks
 from .models import DefaultPlayer
 from .node import Node
 from .nodemanager import NodeManager
 from .playermanager import PlayerManager
 from .events import Event
+
+_event_hooks = {}
 
 
 class Client:
@@ -175,7 +176,7 @@ class Client:
 
         if data['t'] == 'VOICE_SERVER_UPDATE':
             guild_id = int(data['d']['guild_id'])
-            player = self.players.get(guild_id)
+            player = self.player_manager.get(guild_id)
 
             if player:
                 await player._voice_server_update(data['d'])
@@ -184,7 +185,7 @@ class Client:
                 return
 
             guild_id = int(data['d']['guild_id'])
-            player = self.players.get(guild_id)
+            player = self.player_manager.get(guild_id)
 
             if player:
                 await player._voice_state_update(data['d'])

--- a/lavalink/client.py
+++ b/lavalink/client.py
@@ -36,11 +36,16 @@ class Client:
         A dictionary representing region -> discord endpoint. You should only
         change this if you know what you're doing and want more control over
         which regions handle specific locations.
+    connect_back: Optional[bool]
+        A boolean that determines if a player will connect back to the
+        node it was originally connected to. This is not recommended to do since
+        the player will most likely be performing better in the new node.
     """
 
     def __init__(self, user_id: int, shard_count: int = 1,
-                 loop=None, player=DefaultPlayer, regions: dict = None):
+                 loop=None, player=DefaultPlayer, regions: dict = None, connect_back: bool = False):
         self._user_id = str(user_id)
+        self._connect_back = connect_back
         self._shard_count = str(shard_count)
         self._loop = loop or asyncio.get_event_loop()
         self.node_manager = NodeManager(self, regions)

--- a/lavalink/client.py
+++ b/lavalink/client.py
@@ -73,7 +73,7 @@ class Client:
 
         if hook not in event_hooks:
             if not event_hooks:
-                self._event_hooks["Generic"] = [hook]
+                self._event_hooks['Generic'] = [hook]
             else:
                 self._event_hooks[event].append(hook)
 
@@ -220,8 +220,8 @@ class Client:
         :param event:
             The event to dispatch to the hooks.
         """
-        generic_hooks = self._event_hooks.get('Generic') or []
-        targeted_hooks = self._event_hooks.get(event) or []
+        generic_hooks = self._event_hooks.get('Generic', [])
+        targeted_hooks = self._event_hooks.get(event, [])
 
         internal_generic_hooks = _internal_event_hooks.get('Generic', [])
         internal_targeted_hooks = _internal_event_hooks.get(event, [])

--- a/lavalink/client.py
+++ b/lavalink/client.py
@@ -234,5 +234,7 @@ class Client:
                         await hook(event)
                     else:
                         hook(event)
+
+                log.info('Dispatched {} event to all registered hooks'.format(event.__name__))
             except Exception as e:  # pylint: disable=W0703
                 log.warning('Event hook {} encountered an exception!'.format(hook.__name__), e)

--- a/lavalink/client.py
+++ b/lavalink/client.py
@@ -58,13 +58,22 @@ class Client:
             timeout=aiohttp.ClientTimeout(total=30)
         )  # This session will be used for websocket and http requests.
 
-    def add_event_hook(self, hook):
-        event_hooks = self._event_hooks.get('Unknown Event')
+    def add_event_hook(self, hook, event: Event = None):
+        """
+
+        :param hook:
+            The hook to be added, that will be dispatched when an event is dispatched.
+            If `event` parameter is left empty, then it will run when any event is dispatched.
+        :param event:
+            The event the hook belongs to. This will dispatch when that specific event is
+            dispatched.
+        """
+        event_hooks = self._event_hooks.get(event)
         if hook not in event_hooks:
             if event_hooks is None:
-                self._event_hooks['Unknown Event'] = [hook]
+                self._event_hooks[event] = [hook]
             else:
-                self._event_hooks['Unknown Event'].append(hook)
+                self._event_hooks[event].append(hook)
 
     def add_node(self, host: str, port: int, password: str, region: str,
                  resume_key: str = None, resume_timeout: int = 60, name: str = None):
@@ -221,7 +230,7 @@ class Client:
             The event to dispatch to the hooks.
         """
         try:
-            unknown_events = self._event_hooks.get('Unknown Events')
+            unknown_events = self._event_hooks.get(None)
             registered_events = self._event_hooks.get(event)
 
             event_hooks = unknown_events + registered_events

--- a/lavalink/client.py
+++ b/lavalink/client.py
@@ -71,7 +71,7 @@ class Client:
         event_hooks = self._event_hooks.get(event)
 
         if hook not in event_hooks:
-            if event_hooks is None:
+            if not event_hooks:
                 self._event_hooks["Generic"] = [hook]
             else:
                 self._event_hooks[event].append(hook)

--- a/lavalink/events.py
+++ b/lavalink/events.py
@@ -11,7 +11,7 @@ class QueueEndEvent(Event):
     player: BasePlayer
         The player that has no more songs in queue.
     """
-    __slots__ = 'player'
+    __slots__ = ('player',)
 
     def __init__(self, player):
         self.player = player
@@ -149,7 +149,7 @@ class NodeConnectedEvent(Event):
     node: Node
         The node that was successfully connected to.
     """
-    __slots__ = 'node'
+    __slots__ = ('node',)
 
     def __init__(self, node):
         self.node = node

--- a/lavalink/events.py
+++ b/lavalink/events.py
@@ -11,6 +11,8 @@ class QueueEndEvent(Event):
     player: BasePlayer
         The player that has no more songs in queue.
     """
+    __slots__ = 'player'
+
     def __init__(self, player):
         self.player = player
 
@@ -28,6 +30,8 @@ class TrackStuckEvent(Event):
     threshold: int
         The amount of time the track had while being stuck.
     """
+    __slots__ = ('player', 'track', 'threshold')
+
     def __init__(self, player, track, threshold):
         self.player = player
         self.track = track
@@ -47,6 +51,8 @@ class TrackExceptionEvent(Event):
     exception: Exception
         The type of exception that the track had while playing.
     """
+    __slots__ = ('player', 'track', 'exception')
+
     def __init__(self, player, track, exception):
         self.player = player
         self.track = track
@@ -66,6 +72,8 @@ class TrackEndEvent(Event):
     reason: str
         The reason why the track stopped playing.
     """
+    __slots__ = ('player', 'track', 'reason')
+
     def __init__(self, player, track, reason):
         self.player = player
         self.track = track
@@ -83,6 +91,8 @@ class TrackStartEvent(Event):
     track: AudioTrack
         The track that started playing.
     """
+    __slots__ = ('player', 'track')
+
     def __init__(self, player, track):
         self.player = player
         self.track = track
@@ -101,6 +111,8 @@ class PlayerUpdateEvent(Event):
     timestamp: int
         The timestamp that the player is currently on.
     """
+    __slots__ = ('player', 'position', 'timestamp')
+
     def __init__(self, player, position, timestamp):
         self.player = player
         self.position = position
@@ -120,6 +132,8 @@ class NodeDisconnectedEvent(Event):
     reason: str
         The reason of why the node was disconnected.
     """
+    __slots__ = ('node', 'code', 'reason')
+
     def __init__(self, node, code, reason):
         self.node = node
         self.code = code
@@ -135,6 +149,8 @@ class NodeConnectedEvent(Event):
     node: Node
         The node that was successfully connected to.
     """
+    __slots__ = 'node'
+
     def __init__(self, node):
         self.node = node
 
@@ -154,6 +170,8 @@ class NodeChangedEvent(Event):
     new_node: Node
         The node the player was moved to.
     """
+    __slots__ = ('player', 'old_node', 'new_node')
+
     def __init__(self, player, old_node, new_node):
         self.player = player
         self.old_node = old_node
@@ -177,6 +195,8 @@ class WebSocketClosedEvent(Event):
     by_remote: bool
         If the websocket was closed remotely.
     """
+    __slots__ = ('player', 'code', 'reason', 'by_remote')
+
     def __init__(self, player, code, reason, by_remote):
         self.player = player
         self.code = code

--- a/lavalink/exceptions.py
+++ b/lavalink/exceptions.py
@@ -1,6 +1,2 @@
 class NodeException(Exception):
     """ The exception will be raised when something went wrong with a node. """
-
-
-class InvalidBand(Exception):
-    """ The exception will be raised when a equalizer band is invalid. """

--- a/lavalink/exceptions.py
+++ b/lavalink/exceptions.py
@@ -1,2 +1,6 @@
 class NodeException(Exception):
     """ The exception will be raised when something went wrong with a node. """
+
+
+class InvalidBand(Exception):
+    """ The exception will be raised when a equalizer band is invalid. """

--- a/lavalink/models.py
+++ b/lavalink/models.py
@@ -15,6 +15,14 @@ class TrackNotBuilt(Exception):
 
 
 class AudioTrack:
+    """
+    Represents the AudioTrack sent to Lavalink.
+
+    Parameters
+    ----------
+    requester: any
+        The requester of the track.
+    """
     __slots__ = ('track', 'identifier', 'is_seekable', 'author', 'duration', 'stream', 'title', 'uri', 'requester',
                  'extra')
 
@@ -51,6 +59,16 @@ class NoPreviousTrack(Exception):
 
 
 class BasePlayer(ABC):
+    """
+    Represents the BasePlayer all players must be inherited from.
+
+    Parameters
+    ----------
+    guild_id: int
+        The guild id of the player.
+    node: Node
+        The node that the player is connected to.
+    """
     def __init__(self, guild_id: int, node: Node):
         self.guild_id = str(guild_id)
         self.node = node
@@ -99,6 +117,16 @@ class BasePlayer(ABC):
 
 
 class DefaultPlayer(BasePlayer):
+    """
+    The player that Lavalink.py defaults to use.
+
+    Parameters
+    ----------
+    guild_id: int
+        The guild id of the player.
+    node: Node
+        The node that the player is connected to.
+    """
     def __init__(self, guild_id: int, node: Node):
         super().__init__(guild_id, node)
 
@@ -141,10 +169,12 @@ class DefaultPlayer(BasePlayer):
     def store(self, key: object, value: object):
         """
         Stores custom user data.
+
+        Parameters
         ----------
-        :param key:
+        key: object
             The key of the object to store.
-        :param value:
+        value: object
             The object to associate with the key.
         """
         self._user_data.update({key: value})
@@ -152,10 +182,12 @@ class DefaultPlayer(BasePlayer):
     def fetch(self, key: object, default=None):
         """
         Retrieves the related value from the stored user data.
+
+        Parameters
         ----------
-        :param key:
+        key: object
             The key to fetch.
-        :param default:
+        default: Optional[any]
             The object that should be returned if the key doesn't exist.
         """
         return self._user_data.get(key, default)
@@ -163,8 +195,10 @@ class DefaultPlayer(BasePlayer):
     def delete(self, key: object):
         """
         Removes an item from the the stored user data.
+
+        Parameters
         ----------
-        :param key:
+        key: object
             The key to delete.
         """
         try:
@@ -175,14 +209,16 @@ class DefaultPlayer(BasePlayer):
     def add(self, requester: int, track: dict, extra: dict = None, index: int = None):
         """
         Adds a track to the queue.
+
+        Parameters
         ----------
-        :param requester:
+        requester: int
             The ID of the user who requested the track.
-        :param track:
+        track: dict
             A dict representing a track returned from Lavalink.
-        :param extra:
+        extra: dict
             A dict adding extra attributes to the track.
-        :param index:
+        index: Optional[int]
             The index at which to add the track.
             If index is left unspecified, the default behaviour is to append the track.
         """
@@ -194,17 +230,19 @@ class DefaultPlayer(BasePlayer):
     async def play(self, track: AudioTrack = None, start_time: int = 0, end_time: int = 0, no_replace: bool = False):
         """
         Plays the given track.
+
+        Parameters
         ----------
-        :param track:
+        track: AudioTrack
             The track to play. If left unspecified, this will default
             to the first track in the queue.
-        :param start_time:
+        start_time: Optional[int]
             Setting that determines the number of milliseconds to offset the track by.
             If left unspecified, it will start the track at its beginning.
-        :param end_time:
+        end_time: Optional[int]
             Settings that determines the number of milliseconds the track will stop playing.
             By default track plays until it ends as per encoded data.
-        :param no_replace:
+        no_replace: Optional[bool]
             If set to true, operation will be ignored if a track is already playing or paused.
         """
         if self.repeat and self.current:
@@ -259,8 +297,10 @@ class DefaultPlayer(BasePlayer):
     async def set_pause(self, pause: bool):
         """
         Sets the player's paused state.
+
+        Parameters
         ----------
-        :param pause:
+        pause: bool
             Whether to pause the player or not.
         """
         await self.node._send(op='pause', guildId=self.guild_id, pause=pause)
@@ -269,8 +309,10 @@ class DefaultPlayer(BasePlayer):
     async def set_volume(self, vol: int):
         """
         Sets the player's volume (A limit of 1000 is imposed by Lavalink).
+
+        Parameters
         ----------
-        :param vol:
+        vol: int
             The new volume level.
         """
         self.volume = max(min(vol, 1000), 0)
@@ -279,8 +321,10 @@ class DefaultPlayer(BasePlayer):
     async def seek(self, position: int):
         """
         Seeks to a given position in the track.
+
+        Parameters
         ----------
-        :param position:
+        position: int
             The new position to seek to in milliseconds.
         """
         await self.node._send(op='seek', guildId=self.guild_id, position=position)
@@ -288,10 +332,12 @@ class DefaultPlayer(BasePlayer):
     async def set_gain(self, band: int, gain: float = 0.0):
         """
         Sets the equalizer band gain to the given amount.
+
+        Parameters
         ----------
-        :param band:
+        band: int
             Band number (0-14).
-        :param gain:
+        gain: Optional[float]
             A float representing gain of a band (-0.25 to 1.00) Defaults to 0.0.
         """
         await self.set_gains((band, gain))
@@ -299,8 +345,10 @@ class DefaultPlayer(BasePlayer):
     async def set_gains(self, *gain_list):
         """
         Modifies the player's equalizer settings.
+
+        Parameters
         ----------
-        :param gain_list:
+        gain_list: any
             A list of tuples denoting (`band`, `gain`).
         """
         update_package = []
@@ -325,12 +373,27 @@ class DefaultPlayer(BasePlayer):
         await self.set_gains(*[(x, 0.0) for x in range(15)])
 
     async def handle_event(self, event):
-        """ Handles the given event as necessary. """
+        """
+        Handles the given event as necessary.
+
+        Parameters
+        ----------
+        event: Event
+            The event that will be handled.
+        """
         if isinstance(event, (TrackStuckEvent, TrackExceptionEvent)) or \
                 isinstance(event, TrackEndEvent) and event.reason == 'FINISHED':
             await self.play()
 
     async def update_state(self, state: dict):
+        """
+        Updates the position of the player.
+
+        Parameters
+        ----------
+        state: dict
+            The state that is given to update.
+        """
         self.last_update = time() * 1000
         self.last_position = state.get('position', 0)
         self.position_timestamp = state.get('time', 0)
@@ -339,6 +402,14 @@ class DefaultPlayer(BasePlayer):
         await self.node._dispatch_event(event)
 
     async def change_node(self, node: Node):
+        """
+        Changes the player's node
+
+        Parameters
+        ----------
+        node: Node
+            The node the player is changed to.
+        """
         if self.node.available:
             await self.node._send(op='destroy', guildId=self.guild_id)
 

--- a/lavalink/models.py
+++ b/lavalink/models.py
@@ -230,15 +230,15 @@ class DefaultPlayer(BasePlayer):
         self.current = track
         options = {}
 
-        if 0 > start_time > track.duration:
-            raise ValueError('start_time is either less than 0 or greater than the track\'s duration')
-        elif start_time:
+        if not 0 > start_time > track.duration:
             options['startTime'] = start_time
+        else:
+            raise ValueError('start_time is either less than 0 or greater than the track\'s duration')
 
-        if 0 > end_time > track.duration:
-            raise ValueError('end_time is either less than 0 or greater than the track\'s duration')
-        elif end_time:
+        if not 0 > end_time > track.duration:
             options['endTime'] = end_time
+        else:
+            raise ValueError('end_time is either less than 0 or greater than the track\'s duration')
 
         if no_replace:
             options['noReplace'] = no_replace

--- a/lavalink/models.py
+++ b/lavalink/models.py
@@ -230,19 +230,15 @@ class DefaultPlayer(BasePlayer):
         self.current = track
         options = {}
 
-        if not 0 > start_time > track.duration and start_time:
+        if start_time:
+            if 0 > start_time > track.duration:
+                raise ValueError('start_time is either less than 0 or greater than the track\'s duration')
             options['startTime'] = start_time
-        elif start_time == 0:
-            pass
-        else:
-            raise ValueError('start_time is either less than 0 or greater than the track\'s duration')
 
-        if not 0 > end_time > track.duration and end_time:
+        if end_time:
+            if 0 > end_time > track.duration:
+                raise ValueError('end_time is either less than 0 or greater than the track\'s duration')
             options['endTime'] = end_time
-        elif end_time == 0:
-            pass
-        else:
-            raise ValueError('end_time is either less than 0 or greater than the track\'s duration')
 
         if no_replace:
             options['noReplace'] = no_replace

--- a/lavalink/models.py
+++ b/lavalink/models.py
@@ -230,12 +230,12 @@ class DefaultPlayer(BasePlayer):
         self.current = track
         options = {}
 
-        if not 0 > start_time > track.duration:
+        if not 0 > start_time > track.duration and start_time:
             options['startTime'] = start_time
         else:
             raise ValueError('start_time is either less than 0 or greater than the track\'s duration')
 
-        if not 0 > end_time > track.duration:
+        if not 0 > end_time > track.duration and end_time:
             options['endTime'] = end_time
         else:
             raise ValueError('end_time is either less than 0 or greater than the track\'s duration')

--- a/lavalink/models.py
+++ b/lavalink/models.py
@@ -34,12 +34,7 @@ class AudioTrack:
             new_track.stream = track['info']['isStream']
             new_track.title = track['info']['title']
             new_track.uri = track['info']['uri']
-
-            # This is to avoid 'Dangerous default value {} as argument' from pylint
-            if extra is None:
-                extra = {}
-
-            new_track.extra = extra
+            new_track.extra = extra or {}
 
             return new_track
         except KeyError:

--- a/lavalink/models.py
+++ b/lavalink/models.py
@@ -4,7 +4,6 @@ from time import time
 from .events import (TrackStartEvent, TrackStuckEvent, TrackExceptionEvent, TrackEndEvent,
                      QueueEndEvent, PlayerUpdateEvent, NodeChangedEvent)  # noqa: F401
 from .node import Node
-from .exceptions import InvalidBand
 
 
 class InvalidTrack(Exception):
@@ -305,7 +304,7 @@ class DefaultPlayer(BasePlayer):
             gain = value[1]
 
             if not -1 < value[0] < 15:
-                raise InvalidBand('{} is a invalid band, must be 0-14'.format(band))
+                raise IndexError('{} is a invalid band, must be 0-14'.format(band))
 
             gain = max(min(float(gain), 1.0), -0.25)
             update_package.append({'band': band, 'gain': gain})

--- a/lavalink/models.py
+++ b/lavalink/models.py
@@ -230,12 +230,12 @@ class DefaultPlayer(BasePlayer):
         self.current = track
         options = {}
 
-        if 0 > end_time > track.duration or 0 > start_time > track.duration:
-            raise ValueError("end_time or start_time is either less than 0 or greater than the track's duration")
-        elif end_time == 0:
+        if end_time == 0:
             options['endTime'] = track.duration
         elif no_replace:
             options['noReplace'] = no_replace
+        elif 0 > end_time > track.duration or 0 > start_time > track.duration:
+            raise ValueError("end_time or start_time is either less than 0 or greater than the track's duration")
         else:
             options['startTime'] = start_time
 

--- a/lavalink/models.py
+++ b/lavalink/models.py
@@ -230,14 +230,18 @@ class DefaultPlayer(BasePlayer):
         self.current = track
         options = {}
 
-        if end_time == 0:
-            options['endTime'] = track.duration
-        elif no_replace:
-            options['noReplace'] = no_replace
-        elif 0 > end_time > track.duration or 0 > start_time > track.duration:
-            raise ValueError("end_time or start_time is either less than 0 or greater than the track's duration")
-        else:
+        if 0 > start_time > track.duration:
+            raise ValueError('start_time is either less than 0 or greater than the track\'s duration')
+        elif start_time:
             options['startTime'] = start_time
+
+        if 0 > end_time > track.duration:
+            raise ValueError('end_time is either less than 0 or greater than the track\'s duration')
+        elif end_time:
+            options['endTime'] = end_time
+
+        if no_replace:
+            options['noReplace'] = no_replace
 
         await self.node._send(op='play', guildId=self.guild_id, track=track.track, **options)
         await self.node._dispatch_event(TrackStartEvent(self, track))

--- a/lavalink/models.py
+++ b/lavalink/models.py
@@ -23,7 +23,7 @@ class AudioTrack:
         self.preferences = kwargs
 
     @classmethod
-    def build(cls, track, requester, **kwargs):
+    def build(cls, track, requester, extra: dict = {}, **kwargs):
         """ Returns an optional AudioTrack. """
         new_track = cls(requester, **kwargs)
         try:
@@ -35,6 +35,9 @@ class AudioTrack:
             new_track.stream = track['info']['isStream']
             new_track.title = track['info']['title']
             new_track.uri = track['info']['uri']
+
+            for key in extra:
+                setattr(new_track, key, extra[key])
 
             return new_track
         except KeyError:
@@ -172,7 +175,7 @@ class DefaultPlayer(BasePlayer):
         except KeyError:
             pass
 
-    def add(self, requester: int, track: dict, index: int = None):
+    def add(self, requester: int, track: dict, extra: dict = {}, index: int = None):
         """
         Adds a track to the queue.
         ----------
@@ -180,14 +183,16 @@ class DefaultPlayer(BasePlayer):
             The ID of the user who requested the track.
         :param track:
             A dict representing a track returned from Lavalink.
+        :param extra:
+            A dict adding extra attributes to the track.
         :param index:
             The index at which to add the track.
             If index is left unspecified, the default behaviour is to append the track.
         """
         if index is None:
-            self.queue.append(AudioTrack.build(track, requester))
+            self.queue.append(AudioTrack.build(track, requester, extra=extra))
         else:
-            self.queue.insert(index, AudioTrack.build(track, requester))
+            self.queue.insert(index, AudioTrack.build(track, requester, extra=extra))
 
     async def play(self, track: AudioTrack = None, start_time: int = 0):
         """

--- a/lavalink/models.py
+++ b/lavalink/models.py
@@ -37,6 +37,8 @@ class AudioTrack:
             new_track.uri = track['info']['uri']
 
             for key in extra:
+                if key in cls.__slots__:
+                    raise AttributeError("{} is not overwritable as it's a class attribute".format(key))
                 setattr(new_track, key, extra[key])
 
             return new_track

--- a/lavalink/models.py
+++ b/lavalink/models.py
@@ -55,6 +55,7 @@ class BasePlayer(ABC):
         self.guild_id = str(guild_id)
         self.node = node
         self._voice_state = {}
+        self._original_node = None
         self.channel_id = None
 
     @abstractmethod

--- a/lavalink/models.py
+++ b/lavalink/models.py
@@ -229,8 +229,11 @@ class DefaultPlayer(BasePlayer):
                 track = self.queue.pop(0)
 
         self.current = track
+
         if end_time is -1:
             end_time = track.duration
+        elif 0 > end_time > track.duration:
+            raise TypeError("end_time is either less than 0 or greater than the track's duration")
 
         await self.node._send(op='play', guildId=self.guild_id, track=track.track, startTime=start_time,
                               endTime=end_time, noReplace=no_replace)

--- a/lavalink/models.py
+++ b/lavalink/models.py
@@ -16,16 +16,15 @@ class TrackNotBuilt(Exception):
 
 class AudioTrack:
     __slots__ = ('track', 'identifier', 'is_seekable', 'author', 'duration', 'stream', 'title', 'uri', 'requester',
-                 'preferences')
+                 'extra')
 
-    def __init__(self, requester, **kwargs):
+    def __init__(self, requester):
         self.requester = requester
-        self.preferences = kwargs
 
     @classmethod
-    def build(cls, track, requester, extra: dict = {}, **kwargs):
+    def build(cls, track, requester, extra: dict = None):
         """ Returns an optional AudioTrack. """
-        new_track = cls(requester, **kwargs)
+        new_track = cls(requester)
         try:
             new_track.track = track['track']
             new_track.identifier = track['info']['identifier']
@@ -36,10 +35,11 @@ class AudioTrack:
             new_track.title = track['info']['title']
             new_track.uri = track['info']['uri']
 
-            for key in extra:
-                if key in cls.__slots__:
-                    raise AttributeError("{} is not overwritable as it's a class attribute".format(key))
-                setattr(new_track, key, extra[key])
+            # This is to avoid 'Dangerous default value {} as argument' from pylint
+            if extra is None:
+                extra = {}
+
+            new_track.extra = extra
 
             return new_track
         except KeyError:
@@ -177,7 +177,7 @@ class DefaultPlayer(BasePlayer):
         except KeyError:
             pass
 
-    def add(self, requester: int, track: dict, extra: dict = {}, index: int = None):
+    def add(self, requester: int, track: dict, extra: dict = None, index: int = None):
         """
         Adds a track to the queue.
         ----------

--- a/lavalink/models.py
+++ b/lavalink/models.py
@@ -302,7 +302,7 @@ class DefaultPlayer(BasePlayer):
             gain = value[1]
 
             if not -1 < value[0] < 15:
-                raise InvalidBand("{} is a invalid band, must be 0-14".format(band))
+                raise InvalidBand('{} is a invalid band, must be 0-14'.format(band))
 
             gain = max(min(float(gain), 1.0), -0.25)
             update_package.append({'band': band, 'gain': gain})

--- a/lavalink/models.py
+++ b/lavalink/models.py
@@ -232,11 +232,15 @@ class DefaultPlayer(BasePlayer):
 
         if not 0 > start_time > track.duration and start_time:
             options['startTime'] = start_time
+        elif start_time == 0:
+            pass
         else:
             raise ValueError('start_time is either less than 0 or greater than the track\'s duration')
 
         if not 0 > end_time > track.duration and end_time:
             options['endTime'] = end_time
+        elif end_time == 0:
+            pass
         else:
             raise ValueError('end_time is either less than 0 or greater than the track\'s duration')
 

--- a/lavalink/models.py
+++ b/lavalink/models.py
@@ -4,6 +4,7 @@ from time import time
 from .events import (TrackStartEvent, TrackStuckEvent, TrackExceptionEvent, TrackEndEvent,
                      QueueEndEvent, PlayerUpdateEvent, NodeChangedEvent)  # noqa: F401
 from .node import Node
+from .exceptions import InvalidBand
 
 
 class InvalidTrack(Exception):
@@ -300,8 +301,8 @@ class DefaultPlayer(BasePlayer):
             band = value[0]
             gain = value[1]
 
-            if -1 > value[0] > 15:
-                continue
+            if not -1 < value[0] < 15:
+                raise InvalidBand("{} is a invalid band, must be 0-14".format(band))
 
             gain = max(min(float(gain), 1.0), -0.25)
             update_package.append({'band': band, 'gain': gain})

--- a/lavalink/models.py
+++ b/lavalink/models.py
@@ -308,7 +308,7 @@ class DefaultPlayer(BasePlayer):
             gain = value[1]
 
             if not -1 < value[0] < 15:
-                raise IndexError('{} is a invalid band, must be 0-14'.format(band))
+                raise IndexError('{} is an invalid band, must be 0-14'.format(band))
 
             gain = max(min(float(gain), 1.0), -0.25)
             update_package.append({'band': band, 'gain': gain})

--- a/lavalink/node.py
+++ b/lavalink/node.py
@@ -10,6 +10,7 @@ class Node:
                  region: str, name: str, resume_key: str, resume_timeout: int):
         self._manager = manager
         self._ws = WebSocket(self, host, port, password, resume_key, resume_timeout)
+        self._original_players = []
 
         self.host = host
         self.port = port

--- a/lavalink/node.py
+++ b/lavalink/node.py
@@ -3,8 +3,30 @@ from .events import Event
 
 
 class Node:
+    """
+    Represents a Node connection with Lavalink.
+
+    Parameters
+    ----------
+    manager: NodeManager
+        The Node Manager that the Node belongs to.
+    host: str
+        The address of the Lavalink node.
+    port: int
+        The port to use for websocket and REST connections.
+    password: str
+        The password used for authentication.
+    region: str
+        The region to assign this node to.
+    resume_key: str
+        A resume key used for resuming a session upon re-establishing a WebSocket connection to Lavalink.
+    resume_timeout: int
+        How long the node should wait for a connection while disconnected before clearing all players.
+    name: Optional[str]
+        An identifier for the node that will show in logs.
+    """
     def __init__(self, manager, host: str, port: int, password: str,
-                 region: str, name: str, resume_key: str, resume_timeout: int):
+                 region: str, resume_key: str, resume_timeout: int, name: str = None):
         self._manager = manager
         self._ws = WebSocket(self, host, port, password, resume_key, resume_timeout)
         self._original_players = []
@@ -37,8 +59,10 @@ class Node:
     async def get_tracks(self, query: str):
         """
         Gets all tracks associated with the given query.
+
+        Parameters
         ----------
-        :param query:
+        query: str
             The query to perform a search for.
         """
         return await self._manager._lavalink.get_tracks(query, self)
@@ -46,8 +70,10 @@ class Node:
     async def _dispatch_event(self, event: Event):
         """
         Dispatches the given event to all registered hooks.
+
+        Parameters
         ----------
-        :param event:
+        event: Event
             The event to dispatch to the hooks.
         """
         await self._manager._lavalink._dispatch_event(event)
@@ -55,8 +81,10 @@ class Node:
     async def _send(self, **data):
         """
         Sends the given data this node's websocket connection.
+
+        Parameters
         ----------
-        :param data:
+        data: any
             The dict to send to Lavalink.
         """
         await self._ws._send(**data)

--- a/lavalink/node.py
+++ b/lavalink/node.py
@@ -1,8 +1,5 @@
-import logging
 from .websocket import WebSocket
 from .events import Event
-
-log = logging.getLogger('lavalink')
 
 
 class Node:

--- a/lavalink/nodemanager.py
+++ b/lavalink/nodemanager.py
@@ -9,6 +9,7 @@ class NodeManager:
     def __init__(self, lavalink, regions: dict):
         self._lavalink = lavalink
         self._player_queue = []
+        self._original_player_nodes = {}
 
         self.nodes = []
 
@@ -110,6 +111,10 @@ class NodeManager:
         for player in self._player_queue:
             await player.change_node(node)
             log.debug('[NODE-{}] Successfully moved {}'.format(node.name, player.guild_id))
+
+        for player in node._original_players:
+            player.change_node(node)
+
         self._player_queue.clear()
         await self._lavalink._dispatch_event(NodeConnectedEvent(node))
 

--- a/lavalink/nodemanager.py
+++ b/lavalink/nodemanager.py
@@ -53,6 +53,8 @@ class NodeManager:
         node = Node(self, host, port, password, region, name, resume_key, resume_timeout)
         self.nodes.append(node)
 
+        log.info("[NODE-{}] Successfully added Node to Node Manager".format(node.name))
+
     def remove_node(self, node: Node):
         """
         Removes a node.
@@ -61,6 +63,7 @@ class NodeManager:
             The node to remove from the list.
         """
         self.nodes.remove(node)
+        log.info("[NODE-{}] Successfully removed Node".format(node.name))
 
     def get_region(self, endpoint: str):
         """

--- a/lavalink/nodemanager.py
+++ b/lavalink/nodemanager.py
@@ -10,7 +10,7 @@ class NodeManager:
         self.nodes = []
 
         self.regions = regions or {
-            'asia': ('hongkong', 'singapore', 'sydney', 'japan', 'southafrica'),
+            'asia': ('hongkong', 'singapore', 'sydney', 'japan', 'southafrica', 'india'),
             'eu': ('eu', 'amsterdam', 'frankfurt', 'russia', 'london'),
             'us': ('us', 'brazil')
         }

--- a/lavalink/nodemanager.py
+++ b/lavalink/nodemanager.py
@@ -53,7 +53,7 @@ class NodeManager:
         node = Node(self, host, port, password, region, name, resume_key, resume_timeout)
         self.nodes.append(node)
 
-        log.info("[NODE-{}] Successfully added Node to Node Manager".format(node.name))
+        log.info('[NODE-{}] Successfully added to Node Manager'.format(node.name))
 
     def remove_node(self, node: Node):
         """
@@ -63,7 +63,7 @@ class NodeManager:
             The node to remove from the list.
         """
         self.nodes.remove(node)
-        log.info("[NODE-{}] Successfully removed Node".format(node.name))
+        log.info('[NODE-{}] Successfully removed Node'.format(node.name))
 
     def get_region(self, endpoint: str):
         """

--- a/lavalink/nodemanager.py
+++ b/lavalink/nodemanager.py
@@ -120,7 +120,7 @@ class NodeManager:
 
     async def _node_disconnect(self, node: Node, code: int, reason: str):
         self._lavalink._logger.warning('[NODE-{}] Disconnected with code {} and reason {}'.format(node.name, code,
-                                                                                                 reason))
+                                                                                                  reason))
         await self._lavalink._dispatch_event(NodeDisconnectedEvent(node, code, reason))
 
         best_node = self.find_ideal_node(node.region)
@@ -128,7 +128,7 @@ class NodeManager:
         if not best_node:
             self._player_queue.extend(node.players)
             self._lavalink._logger.error('Unable to move players, no available nodes! '
-                                        'Waiting for a node to become available.')
+                                         'Waiting for a node to become available.')
             return
 
         for player in node.players:

--- a/lavalink/nodemanager.py
+++ b/lavalink/nodemanager.py
@@ -3,6 +3,16 @@ from .events import NodeConnectedEvent, NodeDisconnectedEvent
 
 
 class NodeManager:
+    """
+    Represents the node manager that contains all lavalink nodes.
+
+    Parameters
+    ----------
+    lavalink: Client
+        The main client class.
+    regions: dict
+        The possible regions of nodes.
+    """
     def __init__(self, lavalink, regions: dict):
         self._lavalink = lavalink
         self._player_queue = []
@@ -21,32 +31,32 @@ class NodeManager:
 
     @property
     def available_nodes(self):
-        """
-        Returns a list of available nodes.
-        """
+        """ Returns a list of available nodes. """
         return [n for n in self.nodes if n.available]
 
-    def add_node(self, host: str, port: int, password: str, region: str, name: str = None,
-                 resume_key: str = None, resume_timeout: int = 60):
+    def add_node(self, host: str, port: int, password: str, region: str,
+                 resume_key: str = None, resume_timeout: int = 60, name: str = None):
         """
-        Adds a node to your Lavalink server.
+        Adds a node to Lavalink's node manager.
+
+        Parameters
         ----------
-        :param host:
+        host: str
             The address of the Lavalink node.
-        :param port:
+        port: int
             The port to use for websocket and REST connections.
-        :param password:
+        password: str
             The password used for authentication.
-        :param region:
+        region: str
             The region to assign this node to.
-        :param resume_key:
+        resume_key: Optional[str]
             A resume key used for resuming a session upon re-establishing a WebSocket connection to Lavalink.
-        :param resume_timeout:
+        resume_timeout: Optional[int]
             How long the node should wait for a connection while disconnected before clearing all players.
-        :param name:
+        name: Optional[str]
             An identifier for the node that will show in logs.
         """
-        node = Node(self, host, port, password, region, name, resume_key, resume_timeout)
+        node = Node(self, host, port, password, region, resume_key, resume_timeout, name)
         self.nodes.append(node)
 
         self._lavalink._logger.info('[NODE-{}] Successfully added to Node Manager'.format(node.name))
@@ -54,8 +64,10 @@ class NodeManager:
     def remove_node(self, node: Node):
         """
         Removes a node.
+
+        Parameters
         ----------
-        :param node:
+        node: Node
             The node to remove from the list.
         """
         self.nodes.remove(node)
@@ -64,8 +76,10 @@ class NodeManager:
     def get_region(self, endpoint: str):
         """
         Returns a Lavalink.py-friendly region from a Discord voice server address.
+
+        Parameters
         ----------
-        :param endpoint:
+        endpoint: str
             The address of the Discord voice server.
         """
         if not endpoint:
@@ -87,8 +101,10 @@ class NodeManager:
     def find_ideal_node(self, region: str = None):
         """
         Finds the best (least used) node in the given region, if applicable.
+
+        Parameters
         ----------
-        :param region:
+        region: Optional[str]
             The region to find a node in.
         """
         nodes = None
@@ -105,6 +121,14 @@ class NodeManager:
         return best_node
 
     async def _node_connect(self, node: Node):
+        """
+        Called when a node is connected from Lavalink.
+
+        Parameters
+        ----------
+        node: Node
+            The node that has just connected.
+        """
         self._lavalink._logger.info('[NODE-{}] Successfully established connection'.format(node.name))
 
         for player in self._player_queue:
@@ -118,6 +142,16 @@ class NodeManager:
         await self._lavalink._dispatch_event(NodeConnectedEvent(node))
 
     async def _node_disconnect(self, node: Node, code: int, reason: str):
+        """
+        Called when a node is disconnected from Lavalink.
+
+        Parameters
+        ----------
+        node: Node
+            The node that has just connected.
+        code: int
+        reason: str
+        """
         self._lavalink._logger.warning('[NODE-{}] Disconnected with code {} and reason {}'.format(node.name, code,
                                                                                                   reason))
         await self._lavalink._dispatch_event(NodeDisconnectedEvent(node, code, reason))

--- a/lavalink/nodemanager.py
+++ b/lavalink/nodemanager.py
@@ -50,7 +50,7 @@ class NodeManager:
         node = Node(self, host, port, password, region, name, resume_key, resume_timeout)
         self.nodes.append(node)
 
-        self._lavalink.logger.info('[NODE-{}] Successfully added to Node Manager'.format(node.name))
+        self._lavalink._logger.info('[NODE-{}] Successfully added to Node Manager'.format(node.name))
 
     def remove_node(self, node: Node):
         """
@@ -60,7 +60,7 @@ class NodeManager:
             The node to remove from the list.
         """
         self.nodes.remove(node)
-        self._lavalink.logger.info('[NODE-{}] Successfully removed Node'.format(node.name))
+        self._lavalink._logger.info('[NODE-{}] Successfully removed Node'.format(node.name))
 
     def get_region(self, endpoint: str):
         """
@@ -106,11 +106,11 @@ class NodeManager:
         return best_node
 
     async def _node_connect(self, node: Node):
-        self._lavalink.logger.info('[NODE-{}] Successfully established connection'.format(node.name))
+        self._lavalink._logger.info('[NODE-{}] Successfully established connection'.format(node.name))
 
         for player in self._player_queue:
             await player.change_node(node)
-            self._lavalink.logger.debug('[NODE-{}] Successfully moved {}'.format(node.name, player.guild_id))
+            self._lavalink._logger.debug('[NODE-{}] Successfully moved {}'.format(node.name, player.guild_id))
 
         for player in node._original_players:
             player.change_node(node)
@@ -119,7 +119,7 @@ class NodeManager:
         await self._lavalink._dispatch_event(NodeConnectedEvent(node))
 
     async def _node_disconnect(self, node: Node, code: int, reason: str):
-        self._lavalink.logger.warning('[NODE-{}] Disconnected with code {} and reason {}'.format(node.name, code,
+        self._lavalink._logger.warning('[NODE-{}] Disconnected with code {} and reason {}'.format(node.name, code,
                                                                                                  reason))
         await self._lavalink._dispatch_event(NodeDisconnectedEvent(node, code, reason))
 
@@ -127,7 +127,7 @@ class NodeManager:
 
         if not best_node:
             self._player_queue.extend(node.players)
-            self._lavalink.logger.error('Unable to move players, no available nodes! '
+            self._lavalink._logger.error('Unable to move players, no available nodes! '
                                         'Waiting for a node to become available.')
             return
 

--- a/lavalink/nodemanager.py
+++ b/lavalink/nodemanager.py
@@ -6,7 +6,6 @@ class NodeManager:
     def __init__(self, lavalink, regions: dict):
         self._lavalink = lavalink
         self._player_queue = []
-        self._original_player_nodes = {}
 
         self.nodes = []
 

--- a/lavalink/playermanager.py
+++ b/lavalink/playermanager.py
@@ -1,10 +1,6 @@
-import logging
-
 from .node import Node
 from .models import BasePlayer
 from .exceptions import NodeException
-
-log = logging.getLogger('lavalink')
 
 
 class PlayerManager:
@@ -45,7 +41,7 @@ class PlayerManager:
         if player.node and player.node.available:
             await player.node._send(op='destroy', guildId=player.guild_id)
 
-        log.info('[NODE-{}] Successfully destroyed its player'.format(player.node.name))
+        self._lavalink.logger.info('[NODE-{}] Successfully destroyed its player'.format(player.node.name))
 
     def values(self):
         """ Returns an iterator that yields only values. """
@@ -114,5 +110,5 @@ class PlayerManager:
         self.players[guild_id] = player = self.default_player(guild_id, node)
         node._original_players.append(player)
 
-        log.info('[NODE-{}] Successfully created a player'.format(node.name))
+        self._lavalink.logger.info('[NODE-{}] Successfully created a player'.format(node.name))
         return player

--- a/lavalink/playermanager.py
+++ b/lavalink/playermanager.py
@@ -1,6 +1,10 @@
+import logging
+
 from .node import Node
 from .models import BasePlayer
 from .exceptions import NodeException
+
+log = logging.getLogger('lavalink')
 
 
 class PlayerManager:
@@ -40,6 +44,8 @@ class PlayerManager:
 
         if player.node and player.node.available:
             await player.node._send(op='destroy', guildId=player.guild_id)
+
+        log.info("[NODE-{}] Successfully destroyed its player".format(player.node.name))
 
     def values(self):
         """ Returns an iterator that yields only values. """
@@ -108,4 +114,5 @@ class PlayerManager:
         self.players[guild_id] = player = self.default_player(guild_id, node)
         node._original_players.append(player)
 
+        log.info("[NODE-{}] Successfully created a player".format(node.name))
         return player

--- a/lavalink/playermanager.py
+++ b/lavalink/playermanager.py
@@ -45,7 +45,7 @@ class PlayerManager:
         if player.node and player.node.available:
             await player.node._send(op='destroy', guildId=player.guild_id)
 
-        log.info("[NODE-{}] Successfully destroyed its player".format(player.node.name))
+        log.info('[NODE-{}] Successfully destroyed its player'.format(player.node.name))
 
     def values(self):
         """ Returns an iterator that yields only values. """
@@ -114,5 +114,5 @@ class PlayerManager:
         self.players[guild_id] = player = self.default_player(guild_id, node)
         node._original_players.append(player)
 
-        log.info("[NODE-{}] Successfully created a player".format(node.name))
+        log.info('[NODE-{}] Successfully created a player'.format(node.name))
         return player

--- a/lavalink/playermanager.py
+++ b/lavalink/playermanager.py
@@ -106,4 +106,6 @@ class PlayerManager:
             raise NodeException('No available nodes!')
 
         self.players[guild_id] = player = self.default_player(guild_id, node)
+        node._original_players.append(player)
+
         return player

--- a/lavalink/playermanager.py
+++ b/lavalink/playermanager.py
@@ -4,6 +4,16 @@ from .exceptions import NodeException
 
 
 class PlayerManager:
+    """
+    Represents the player manager that contains all the players.
+
+    Parameters
+    ----------
+    lavalink: Client
+        The main client class.
+    player: BasePlayer
+        The player that the player manager is initialized with.
+    """
     def __init__(self, lavalink, player):
         if not issubclass(player, BasePlayer):
             raise ValueError('Player must implement BasePlayer or DefaultPlayer.')
@@ -29,8 +39,9 @@ class PlayerManager:
         ONLY USE THIS IF YOU KNOW WHAT YOU'RE DOING!
         Usage of this function may lead to invalid cache states!
 
+        Parameters
         ----------
-        :param guild_id:
+        guild_id: int
             The guild_id associated with the player to remove.
         """
         if guild_id not in self.players:
@@ -48,15 +59,29 @@ class PlayerManager:
         for player in self.players.values():
             yield player
 
-    def find_all(self, predicate):
-        """ Returns a list of players that match the given predicate. """
+    def find_all(self, predicate=None):
+        """
+        Returns a list of players that match the given predicate.
+
+        Parameters
+        ----------
+        predicate: Optional[function]
+
+        """
         if not predicate:
             return list(self.players.values())
 
         return [p for p in self.players.values() if bool(predicate(p))]
 
     def remove(self, guild_id: int):
-        """ Removes a player from the internal cache. """
+        """
+        Removes a player from the internal cache.
+
+        Parameters
+        ----------
+        guild_id: int
+            The player that will be removed.
+        """
         if guild_id in self.players:
             player = self.players.pop(guild_id)
             player.cleanup()
@@ -64,8 +89,10 @@ class PlayerManager:
     def get(self, guild_id: int):
         """
         Gets a player from cache.
+
+        Parameters
         ----------
-        :param guild_id:
+        guild_id: int
             The guild_id associated with the player to get.
         """
         return self.players.get(guild_id)
@@ -83,14 +110,16 @@ class PlayerManager:
         Lavalink.py will fall back to the node with the lowest penalty.
 
         Region can be omitted if node is specified and vice-versa.
+
+        Parameters
         ----------
-        :param guild_id:
+        guild_id: int
             The guild_id to associate with the player.
-        :param region:
+        region: str
             The region to use when selecting a Lavalink node.
-        :param endpoint:
+        endpoint: str
             The address of the Discord voice server.
-        :param node:
+        node: Node
             The node to put the player on.
         """
         if guild_id in self.players:

--- a/lavalink/playermanager.py
+++ b/lavalink/playermanager.py
@@ -41,7 +41,7 @@ class PlayerManager:
         if player.node and player.node.available:
             await player.node._send(op='destroy', guildId=player.guild_id)
 
-        self._lavalink.logger.info('[NODE-{}] Successfully destroyed its player'.format(player.node.name))
+        self._lavalink._logger.info('[NODE-{}] Successfully destroyed its player'.format(player.node.name))
 
     def values(self):
         """ Returns an iterator that yields only values. """
@@ -110,5 +110,5 @@ class PlayerManager:
         self.players[guild_id] = player = self.default_player(guild_id, node)
         node._original_players.append(player)
 
-        self._lavalink.logger.info('[NODE-{}] Successfully created a player'.format(node.name))
+        self._lavalink._logger.info('[NODE-{}] Successfully created a player'.format(node.name))
         return player

--- a/lavalink/stats.py
+++ b/lavalink/stats.py
@@ -1,4 +1,12 @@
 class Penalty:
+    """
+    Represents the penalty of the stats of a Node.
+
+    Parameters
+    ----------
+    stats: Stats
+        Stats of the Node.
+    """
     __slots__ = ('player_penalty', 'cpu_penalty', 'null_frame_penalty', 'deficit_frame_penalty', 'total')
 
     def __init__(self, stats):
@@ -18,6 +26,16 @@ class Penalty:
 
 
 class Stats:
+    """
+    Represents the stats of Lavalink node.
+
+    Parameters
+    ----------
+    node: Node
+        The node of the stats
+    data: dict
+        The Lavalink data of the stats of the node.
+    """
     __slots__ = ('_node', 'uptime', 'players', 'playing_players', 'memory_free', 'memory_used', 'memory_allocated',
                  'memory_reservable', 'cpu_cores', 'system_load', 'lavalink_load', 'frames_sent', 'frames_nulled',
                  'frames_deficit', 'penalty')

--- a/lavalink/stats.py
+++ b/lavalink/stats.py
@@ -1,4 +1,6 @@
 class Penalty:
+    __slots__ = ("player_penalty", "cpu_penalty", "null_frame_penalty", "deficit_frame_penalty", "total")
+
     def __init__(self, stats):
         self.player_penalty = stats.playing_players
         self.cpu_penalty = 1.05 ** (100 * stats.system_load) * 10 - 10
@@ -16,6 +18,10 @@ class Penalty:
 
 
 class Stats:
+    __slots__ = ("_node", "uptime", "players", "playing_players", "memory_free", "memory_used", "memory_allocated",
+                 "memory_reservable", "cpu_cores", "system_load", "lavalink_load", "frames_sent", "frames_nulled",
+                 "frames_deficit", "penalty")
+
     def __init__(self, node, data):
         self._node = node
 

--- a/lavalink/stats.py
+++ b/lavalink/stats.py
@@ -1,5 +1,5 @@
 class Penalty:
-    __slots__ = ("player_penalty", "cpu_penalty", "null_frame_penalty", "deficit_frame_penalty", "total")
+    __slots__ = ('player_penalty', 'cpu_penalty', 'null_frame_penalty', 'deficit_frame_penalty', 'total')
 
     def __init__(self, stats):
         self.player_penalty = stats.playing_players
@@ -18,9 +18,9 @@ class Penalty:
 
 
 class Stats:
-    __slots__ = ("_node", "uptime", "players", "playing_players", "memory_free", "memory_used", "memory_allocated",
-                 "memory_reservable", "cpu_cores", "system_load", "lavalink_load", "frames_sent", "frames_nulled",
-                 "frames_deficit", "penalty")
+    __slots__ = ('_node', 'uptime', 'players', 'playing_players', 'memory_free', 'memory_used', 'memory_allocated',
+                 'memory_reservable', 'cpu_cores', 'system_load', 'lavalink_load', 'frames_sent', 'frames_nulled',
+                 'frames_deficit', 'penalty')
 
     def __init__(self, node, data):
         self._node = node

--- a/lavalink/utils.py
+++ b/lavalink/utils.py
@@ -1,8 +1,10 @@
 def format_time(time):
     """
     Formats the given time into HH:MM:SS.
+
+    Parameters
     ----------
-    :param time:
+    time: int
         The time in milliseconds.
     """
     hours, remainder = divmod(time / 1000, 3600)
@@ -15,8 +17,10 @@ def parse_time(time):
     """
     Parses the given time into days, hours, minutes and seconds.
     Useful for formatting time yourself.
+
+    Parameters
     ----------
-    :param time:
+    time: int
         The time in milliseconds.
     """
     days, remainder = divmod(time / 1000, 86400)

--- a/lavalink/websocket.py
+++ b/lavalink/websocket.py
@@ -4,8 +4,6 @@ import aiohttp
 from .stats import Stats
 from .events import TrackEndEvent, TrackExceptionEvent, TrackStuckEvent, WebSocketClosedEvent
 
-log = logging.getLogger('lavalink')
-
 
 class WebSocket:
     def __init__(self, node, host: str, port: int, password: str, resume_key: str, resume_timeout: int):
@@ -60,7 +58,7 @@ class WebSocket:
                                                           heartbeat=60)
             except aiohttp.ClientConnectorError:
                 if attempt == 1:
-                    log.warning('[NODE-{}] Failed to establish connection!'.format(self._node.name))
+                    self._lavalink.warning('[NODE-{}] Failed to establish connection!'.format(self._node.name))
 
                 backoff = min(10 * attempt, 60)
                 await asyncio.sleep(backoff)
@@ -81,7 +79,7 @@ class WebSocket:
 
     async def _listen(self):
         async for msg in self._ws:
-            log.debug('[NODE-{}] Received WebSocket message: {}'.format(self._node.name, msg.data))
+            self._lavalink.logger.debug('[NODE-{}] Received WebSocket message: {}'.format(self._node.name, msg.data))
 
             if msg.type == aiohttp.WSMsgType.text:
                 await self._handle_message(msg.json())
@@ -110,14 +108,14 @@ class WebSocket:
         elif op == 'event':
             await self._handle_event(data)
         else:
-            log.warning('[NODE-{}] Received unknown op: {}'.format(self._node.name, op))
+            self._lavalink.logger.warning('[NODE-{}] Received unknown op: {}'.format(self._node.name, op))
 
     async def _handle_event(self, data: dict):
         player = self._lavalink.players.get(int(data['guildId']))
 
         if not player:
-            log.warning('[NODE-{}] Received event for non-existent player! GuildId: {}'.format(self._node.name,
-                                                                                               data['guildId']))
+            self._lavalink.logger.warning('[NODE-{}] Received event for non-existent player! GuildId: {}'
+                                          .format(self._node.name, data['guildId']))
             return
 
         event_type = data['type']
@@ -132,7 +130,7 @@ class WebSocket:
         elif event_type == 'WebSocketClosedEvent':
             event = WebSocketClosedEvent(player, data['code'], data['reason'], data['byRemote'])
         else:
-            log.warning('[NODE-{}] Unknown event received: {}'.format(self._node.name, event_type))
+            self._lavalink.logger.warning('[NODE-{}] Unknown event received: {}'.format(self._node.name, event_type))
             return
 
         await self._lavalink._dispatch_event(event)
@@ -142,8 +140,8 @@ class WebSocket:
 
     async def _send(self, **data):
         if self.connected:
-            log.debug('[NODE-{}] Sending payload {}'.format(self._node.name, str(data)))
+            self._lavalink.logger.debug('[NODE-{}] Sending payload {}'.format(self._node.name, str(data)))
             await self._ws.send_json(data)
         else:
-            log.debug('[NODE-{}] Send called before WebSocket ready!'.format(self._node.name))
+            self._lavalink.logger.debug('[NODE-{}] Send called before WebSocket ready!'.format(self._node.name))
             self._message_queue.append(data)

--- a/lavalink/websocket.py
+++ b/lavalink/websocket.py
@@ -1,5 +1,4 @@
 import asyncio
-import logging
 import aiohttp
 from .stats import Stats
 from .events import TrackEndEvent, TrackExceptionEvent, TrackStuckEvent, WebSocketClosedEvent
@@ -115,7 +114,7 @@ class WebSocket:
 
         if not player:
             self._lavalink._logger.warning('[NODE-{}] Received event for non-existent player! GuildId: {}'
-                                          .format(self._node.name, data['guildId']))
+                                           .format(self._node.name, data['guildId']))
             return
 
         event_type = data['type']

--- a/lavalink/websocket.py
+++ b/lavalink/websocket.py
@@ -79,7 +79,7 @@ class WebSocket:
 
     async def _listen(self):
         async for msg in self._ws:
-            self._lavalink.logger.debug('[NODE-{}] Received WebSocket message: {}'.format(self._node.name, msg.data))
+            self._lavalink._logger.debug('[NODE-{}] Received WebSocket message: {}'.format(self._node.name, msg.data))
 
             if msg.type == aiohttp.WSMsgType.text:
                 await self._handle_message(msg.json())
@@ -108,13 +108,13 @@ class WebSocket:
         elif op == 'event':
             await self._handle_event(data)
         else:
-            self._lavalink.logger.warning('[NODE-{}] Received unknown op: {}'.format(self._node.name, op))
+            self._lavalink._logger.warning('[NODE-{}] Received unknown op: {}'.format(self._node.name, op))
 
     async def _handle_event(self, data: dict):
         player = self._lavalink.players.get(int(data['guildId']))
 
         if not player:
-            self._lavalink.logger.warning('[NODE-{}] Received event for non-existent player! GuildId: {}'
+            self._lavalink._logger.warning('[NODE-{}] Received event for non-existent player! GuildId: {}'
                                           .format(self._node.name, data['guildId']))
             return
 
@@ -130,7 +130,7 @@ class WebSocket:
         elif event_type == 'WebSocketClosedEvent':
             event = WebSocketClosedEvent(player, data['code'], data['reason'], data['byRemote'])
         else:
-            self._lavalink.logger.warning('[NODE-{}] Unknown event received: {}'.format(self._node.name, event_type))
+            self._lavalink._logger.warning('[NODE-{}] Unknown event received: {}'.format(self._node.name, event_type))
             return
 
         await self._lavalink._dispatch_event(event)
@@ -140,8 +140,8 @@ class WebSocket:
 
     async def _send(self, **data):
         if self.connected:
-            self._lavalink.logger.debug('[NODE-{}] Sending payload {}'.format(self._node.name, str(data)))
+            self._lavalink._logger.debug('[NODE-{}] Sending payload {}'.format(self._node.name, str(data)))
             await self._ws.send_json(data)
         else:
-            self._lavalink.logger.debug('[NODE-{}] Send called before WebSocket ready!'.format(self._node.name))
+            self._lavalink._logger.debug('[NODE-{}] Send called before WebSocket ready!'.format(self._node.name))
             self._message_queue.append(data)


### PR DESCRIPTION
### Checks and guidelines:
<!-- Mark your checks with 'x' inside the square brackets -->

* [x] Have you checked that there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you checked that only **single quotes** are used in the code, apart from the doc-strings?
* [x] Have you run a lint program on your code prior to submission?
* [x] Have you checked if `python run_tests.py` returns no errors?

Tests output: 
```
-- flake8 test --
OK
-- pylint test --
OK
```

<!-- You can erase any part of this template if not applicable to your Pull Request. -->

### Type of change

* [x] Bug fix
* [x] New feature
* [x] Improvement
* [x] Breaking change
* [x] This change is a documentation update

### Describe the changes:

- Added Event Hook Decorators, changed `Client._event_hooks` to a dictionary for better compatibility with Decorators. `None` key are all the unknown event hooks, meaning we don't know what even they belong to, but the keys with `Event` are the keys we know what events they belong to. This is more efficient so we don't have to dispatch every single function. 

- Added `connect_back` parameter to `Client`, allowing users to be able to have the player connect to their original node that they connected to from it's current node. 

- Removed `AudioTrack.preferences` and replaced with `AudioTrack.extras`, this is now a dictionary full of extra info. about the `AudioTrack`. 

- Added `__slots__` for `Stats` and `Penalty`, for better memory stuff. 

- Fixed EQ Bands conditional in `DefaultPlayer.set_gains()` which can never be true, to check if it's an invalid band and if so it will raise `InvalidBand`, which is a new exception added. 

- Added and documented `end_time` and `no_replace` parameters in `DefaultPlayer.play()`. `end_time` defaults to -1 and is changed to `AudioTrack.duration`, if it is set, it's checked if it's less than 0 or greater than `AudioTrack.duration`. `no_replace` is also defaulted as `False`.
  
- Fixed Copyright Year from 2018 -> 2019. 