### PR TITLE
Fix for Event Hook Decorators + Rework 

### DIFF
--- a/examples/music.py
+++ b/examples/music.py
@@ -12,7 +12,7 @@ from discord.ext import commands
 url_rx = re.compile('https?:\\/\\/(?:www\\.)?.+')  # noqa: W605
 
 
-class Music(commands.Cog):
+class Music(commands.Cog, lavalink.ListenerAdapter):
     def __init__(self, bot):
         self.bot = bot
 
@@ -22,6 +22,9 @@ class Music(commands.Cog):
             bot.add_listener(bot.lavalink.voice_update_handler, 'on_socket_response')
 
         lavalink.add_event_hook(self.track_hook)
+
+        # Registers the ListenerAdapter, so it allows us to be able to register event hooks with decorators
+        lavalink.add_adapter(self)
 
     def cog_unload(self):
         self.bot.lavalink._event_hooks.clear()
@@ -53,8 +56,8 @@ class Music(commands.Cog):
 
     # You can create event hooks by decorators too.
     @lavalink.on(lavalink.events.TrackStartEvent)
-    async def on_track_start(self, event):
-        print('{} has just started playing!'.format(event.track.title))
+    async def on_track_start(self, player, track):
+        print('{} has just started playing!'.format(track.title))
 
     async def connect_to(self, guild_id: int, channel_id: str):
         """ Connects to the given voicechannel ID. A channel_id of `None` means disconnect. """

--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -123,6 +123,7 @@ def on(event: Event = None):
             func.__arg_count = func.__code__.co_argcount - 1
         else:
             func.__arg_count = func.__code__.co_argcount
+            add_event_hook(func, event=event)
 
         @functools.wraps(func)
         async def decorated_func(*args, **kwargs):


### PR DESCRIPTION
### Checks and guidelines:
<!-- Mark your checks with 'x' inside the square brackets -->

* [x] Have you checked that there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you checked that only **single quotes** are used in the code, apart from the doc-strings?
* [x] Have you run a lint program on your code prior to submission?
* [x] Have you checked if `python run_tests.py` returns no errors?

Tests output: 
```
-- flake8 test --
OK
-- pylint test --
OK
```

<!-- You can erase any part of this template if not applicable to your Pull Request. -->

### Type of change

* [x] Bug fix
* [x] New feature
* [x] Improvement
* [] Breaking change
* [ ] This change is a documentation update

### Describe the changes:

- If event hooks are to be added with decorators, they must be in a class that derives from `lavalink.ListenerAdapter` then they must be registered through `lavalink.add_adapter()`, otherwise they will work perfectly fine.
- Event hooks now can have the parameters of the event or just have one parameter, example: 
```py
import lavalink
from lavalink.events import * 

class MyListeners(lavalink.ListenerAdapter):
      # This works
     @lavalink.on(TrackStartEvent)
     async def on_track_start(player, track): pass 

     # This works too! 
     @lavalink.on(TrackStartEvent)
    async def onTrackStart(event): pass 

lavalink.add_adapter(MyListeners())
```