### PR TITLE
Fix checking bounds on start_time and end_time

### DIFF
--- a/lavalink/models.py
+++ b/lavalink/models.py
@@ -310,7 +310,7 @@ class DefaultPlayer(BasePlayer):
             options['startTime'] = start_time
 
         if end_time is not None:
-            if not isinstance(start_time, int) or not 0 <= end_time <= track.duration:
+            if not isinstance(end_time, int) or not 0 <= end_time <= track.duration:
                 raise ValueError('end_time is either less than 0 or greater than the track\'s duration')
             options['endTime'] = end_time
 

--- a/lavalink/models.py
+++ b/lavalink/models.py
@@ -311,7 +311,7 @@ class DefaultPlayer(BasePlayer):
 
         if end_time is not None:
             if not isinstance(end_time, int) or not 0 <= end_time <= track.duration:
-                raise ValueError('end_time is either less than 0 or greater than the track\'s duration')
+                raise ValueError('end_time must be an int with a value equal to, or greater than 0, and less than the track duration')
             options['endTime'] = end_time
 
         options['noReplace'] = no_replace

--- a/lavalink/models.py
+++ b/lavalink/models.py
@@ -306,7 +306,7 @@ class DefaultPlayer(BasePlayer):
 
         if start_time is not None:
             if not isinstance(start_time, int) or not 0 <= start_time <= track.duration:
-                raise ValueError('start_time is either less than 0 or greater than the track\'s duration')
+                raise ValueError('start_time must be an int with a value equal to, or greater than 0, and less than the track duration')
             options['startTime'] = start_time
 
         if end_time is not None:

--- a/lavalink/models.py
+++ b/lavalink/models.py
@@ -265,7 +265,7 @@ class DefaultPlayer(BasePlayer):
 
         Parameters
         ----------
-        track: Union[:class:`AudioTrack`, :class:`dict`]
+        track: Optional[Union[:class:`AudioTrack`, :class:`dict`]]
             The track to play. If left unspecified, this will default
             to the first track in the queue. Defaults to `None` so plays the next
             song in queue. Accepts either an AudioTrack or a dict representing a track

--- a/lavalink/models.py
+++ b/lavalink/models.py
@@ -237,7 +237,7 @@ class DefaultPlayer(BasePlayer):
         except KeyError:
             pass
 
-    def add(self, requester: int, track: typing.Union[dict, AudioTrack], index: int = None):
+    def add(self, requester: int, track: typing.Union[AudioTrack, dict], index: int = None):
         """
         Adds a track to the queue.
 
@@ -245,8 +245,9 @@ class DefaultPlayer(BasePlayer):
         ----------
         requester: :class:`int`
             The ID of the user who requested the track.
-        track: :class:`dict`
-            A dict representing a track returned from Lavalink.
+        track: Union[:class:`AudioTrack`, :class:`dict`]
+            The track to add. Accepts either an AudioTrack or
+            a dict representing a track returned from Lavalink.
         index: Optional[:class:`int`]
             The index at which to add the track.
             If index is left unspecified, the default behaviour is to append the track. Defaults to `None`.
@@ -258,16 +259,17 @@ class DefaultPlayer(BasePlayer):
         else:
             self.queue.insert(index, at)
 
-    async def play(self, track: AudioTrack = None, start_time: int = 0, end_time: int = 0, no_replace: bool = False):
+    async def play(self, track: typing.Union[AudioTrack, dict] = None, start_time: int = 0, end_time: int = 0, no_replace: bool = False):
         """
         Plays the given track.
 
         Parameters
         ----------
-        track: :class:`AudioTrack`
+        track: Union[:class:`AudioTrack`, :class:`dict`]
             The track to play. If left unspecified, this will default
             to the first track in the queue. Defaults to `None` so plays the next
-            song in queue.
+            song in queue. Accepts either an AudioTrack or a dict representing a track
+            returned from Lavalink.
         start_time: Optional[:class:`int`]
             Setting that determines the number of milliseconds to offset the track by.
             If left unspecified, it will start the track at its beginning. Defaults to `0`,
@@ -302,18 +304,17 @@ class DefaultPlayer(BasePlayer):
 
         options = {}
 
-        if start_time:
-            if 0 > start_time > track.duration:
+        if start_time is not None:
+            if not 0 <= start_time <= track.duration:
                 raise ValueError('start_time is either less than 0 or greater than the track\'s duration')
             options['startTime'] = start_time
 
-        if end_time:
-            if 0 > end_time > track.duration:
+        if end_time is not None:
+            if not 0 <= end_time <= track.duration:
                 raise ValueError('end_time is either less than 0 or greater than the track\'s duration')
             options['endTime'] = end_time
 
-        if no_replace:
-            options['noReplace'] = no_replace
+        options['noReplace'] = no_replace
 
         self.current = track
         await self.node._send(op='play', guildId=self.guild_id, track=track.track, **options)

--- a/lavalink/models.py
+++ b/lavalink/models.py
@@ -314,6 +314,10 @@ class DefaultPlayer(BasePlayer):
                 raise ValueError('end_time must be an int with a value equal to, or greater than 0, and less than the track duration')
             options['endTime'] = end_time
 
+        if no_replace is None:
+            no_replace = False
+        if not isinstance(no_replace, bool):
+            raise TypeError('no_replace must be a bool')
         options['noReplace'] = no_replace
 
         self.current = track

--- a/lavalink/models.py
+++ b/lavalink/models.py
@@ -305,12 +305,12 @@ class DefaultPlayer(BasePlayer):
         options = {}
 
         if start_time is not None:
-            if not 0 <= start_time <= track.duration:
+            if not isinstance(start_time, int) or not 0 <= start_time <= track.duration:
                 raise ValueError('start_time is either less than 0 or greater than the track\'s duration')
             options['startTime'] = start_time
 
         if end_time is not None:
-            if not 0 <= end_time <= track.duration:
+            if not isinstance(start_time, int) or not 0 <= end_time <= track.duration:
                 raise ValueError('end_time is either less than 0 or greater than the track\'s duration')
             options['endTime'] = end_time
 


### PR DESCRIPTION
### Checks and guidelines:
<!-- Mark your checks with 'x' inside the square brackets -->

* [x] Have you checked that there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you checked that only **single quotes** are used in the code, apart from the doc-strings?
* [x] Have you run a lint program on your code prior to submission?
* [x] Have you checked if `python run_tests.py` returns no errors?

Tests output: [link](https://api.travis-ci.com/v3/job/360672377/log.txt) <!-- use 'paste.ubuntu.com', 'hastebin.com' or similar -->
TravisCI build: [link](https://travis-ci.com/github/burtonwilliamt/Lavalink.py/builds/175470555)
<!-- You can erase any part of this template if not applicable to your Pull Request. -->

### Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Improvement
* [ ] Breaking change
* [x] This change is a documentation update

### Describe the changes:

- fix start_time and end_time bounds
- none check using 'if x is not None' istead of 'if x'
- switch type hinting and docstrings of DefaultPlayer .add() and .play()
to be Union(AudioTrack, dict)
