### PR TITLE
support new lavalink exception format

### DIFF
--- a/lavalink/events.py
+++ b/lavalink/events.py
@@ -75,15 +75,18 @@ class TrackExceptionEvent(Event):
         The player that had the exception occur while playing a track.
     track: :class:`AudioTrack`
         The track that had the exception while playing.
-    exception: :class:`Exception`
+    exception: :class:`str`
         The type of exception that the track had while playing.
+    severity: :class:`str`
+        The level of severity of the exception.
     """
-    __slots__ = ('player', 'track', 'exception')
+    __slots__ = ('player', 'track', 'exception', 'severity')
 
-    def __init__(self, player, track, exception):
+    def __init__(self, player, track, exception, severity):
         self.player = player
         self.track = track
         self.exception = exception
+        self.severity = severity
 
 
 class TrackEndEvent(Event):

--- a/lavalink/websocket.py
+++ b/lavalink/websocket.py
@@ -214,7 +214,10 @@ class WebSocket:
             track = decode_track(data['track'])
             event = TrackEndEvent(player, track, data['reason'])
         elif event_type == 'TrackExceptionEvent':
-            event = TrackExceptionEvent(player, player.current, data['error'])
+            exc_inner = data.get('exception', {})
+            exception = data.get('error') or exc_inner.get('cause', 'Unknown exception')
+            severity = exc_inner.get('severity', 'UNKNOWN')
+            event = TrackExceptionEvent(player, player.current, exception, severity)
         elif event_type == 'TrackStartEvent':
             pass
         #    event = TrackStartEvent(player, player.current)


### PR DESCRIPTION
### Checks and guidelines:
<!-- Mark your checks with 'x' inside the square brackets -->

* [x] Have you checked that there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you checked that only **single quotes** are used in the code, apart from the doc-strings?
* [x] Have you run a lint program on your code prior to submission?
* [x] Have you checked if `python run_tests.py` returns no errors?

Tests output: [link](https://paste.ubuntu.com/p/ynvBNNS8X4/) <!-- use 'paste.ubuntu.com', 'hastebin.com' or similar -->

<!-- You can erase any part of this template if not applicable to your Pull Request. -->

### Type of change

* [x] Bug fix
* [ ] New feature
* [x] Improvement
* [ ] Breaking change
* [x] This change is a documentation update

### Describe the changes:

- Recent Lavalink builds have changed the format of `TrackExceptionEvent`s. This PR fixes issues in Lavalink.py by supporting these changes whilst maintaining compatibility with older builds that use the old format.
