### PR TITLE
Update VoiceProtocol example for latest discord.py change

### DIFF
--- a/examples/music.py
+++ b/examples/music.py
@@ -57,14 +57,14 @@ class LavalinkVoiceClient(discord.VoiceClient):
                 }
         await self.lavalink.voice_update_handler(lavalink_data)
 
-    async def connect(self, *, timeout: float, reconnect: bool) -> None:
+    async def connect(self, *, timeout: float, reconnect: bool, self_deaf: bool = False, self_mute: bool = False) -> None:
         """
         Connect the bot to the voice channel and create a player_manager
         if it doesn't exist yet.
         """
         # ensure there is a player_manager when creating a new voice_client
         self.lavalink.player_manager.create(guild_id=self.channel.guild.id)
-        await self.channel.guild.change_voice_state(channel=self.channel)
+        await self.channel.guild.change_voice_state(channel=self.channel, self_mute=self_mute, self_deaf=self_deaf)
 
     async def disconnect(self, *, force: bool) -> None:
         """


### PR DESCRIPTION
There was a breaking change a few days ago involving VoiceProtocol in the master branch of discord.py, you can see more information about it here https://github.com/Rapptz/discord.py/pull/7886.

This patch should be backwards compatible with v1.7 due to the usage of default arguments while simultaneously being forward compatible with the v2 breaking change.

I have not run any linters on this code. The maximum line length of 300 should be respected even with this change and I see no reason for the tests to fail. I've made similar PRs to other lavalink libraries using VoiceProtocol as well.