### PR TITLE
Fix extra kwargs not being accounted for in track duplication

### DIFF
--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -4,7 +4,7 @@ __title__ = 'Lavalink'
 __author__ = 'Devoxin'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2017-present Devoxin'
-__version__ = '4.0.1'
+__version__ = '4.0.2'
 
 
 import inspect

--- a/lavalink/models.py
+++ b/lavalink/models.py
@@ -84,7 +84,7 @@ class AudioTrack:
     def __init__(self, data: dict, requester: int, **extra):
         try:
             if isinstance(data, AudioTrack):
-                extra = data.extra
+                extra = {**data.extra, **extra}
                 data = data._raw
 
             self._raw = data


### PR DESCRIPTION
### Checks and guidelines:
<!-- Mark your checks with 'x' inside the square brackets -->

* [ ] Have you checked that there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [ ] Have you checked that only **single quotes** are used in the code, apart from the doc-strings?
* [ ] Have you run a lint program on your code prior to submission?
* [ ] Have you checked if `python run_tests.py` returns no errors?

Tests output: [link](https://put-your-link-to-your-output.here) <!-- use 'paste.ubuntu.com', 'hastebin.com' or similar -->

<!-- You can erase any part of this template if not applicable to your Pull Request. -->

### Type of change

* [ ] Bug fix
* [ ] New feature
* [ ] Improvement
* [ ] Breaking change
* [ ] This change is a documentation update

### Describe the changes:

- I've added <this> by <doing that>
- Removed <this> because <of that>
