### PR TITLE
Fix "TypeError: Passing coroutines is forbidden, use tasks explicitly."

### DIFF
--- a/lavalink/client.py
+++ b/lavalink/client.py
@@ -383,7 +383,7 @@ class Client:
                 #  clarity.
 
         tasks = [_hook_wrapper(hook, event) for hook in itertools.chain(generic_hooks, targeted_hooks)]
-        await asyncio.wait(tasks)
+        await asyncio.gather(*tasks)
 
         _log.debug('Dispatched \'%s\' to all registered hooks', type(event).__name__)
 


### PR DESCRIPTION
### Checks and guidelines:
<!-- Mark your checks with 'x' inside the square brackets -->

* [x] Have you checked that there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you checked that only **single quotes** are used in the code, apart from the doc-strings?
* [x] Have you run a lint program on your code prior to submission?
* [x] Have you checked if `python run_tests.py` returns no errors?

### Type of change

* [x] Bug fix

### Describe the changes:
Use asyncio.gather instead of asyncio.wait for tasks in lavalink/client.py _hook_wrapper
This fixes `TypeError: Passing coroutines is forbidden, use tasks explicitly.` which I kept getting after moving to python 3.11.0

And to be blunt I don't know what I am doing I just know that this fixes an error I was receiving while using this in my discord bot. This should in theory have no negative repercussions afaik.
