### PR TITLE
Fix end_time check

### DIFF
--- a/lavalink/models.py
+++ b/lavalink/models.py
@@ -367,7 +367,7 @@ class BasePlayer(ABC):
             options['startTime'] = start_time
 
         if end_time is not None:
-            if not isinstance(end_time, int) or not end_time <= 0:
+            if not isinstance(end_time, int) or not end_time >= 0:
                 raise ValueError('end_time must be an int with a value equal to, or greater than 0')
 
             if end_time > 0:


### PR DESCRIPTION
### Checks and guidelines:
<!-- Mark your checks with 'x' inside the square brackets -->

* [x] Have you checked that there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you checked that only **single quotes** are used in the code, apart from the doc-strings?
* [x] Have you run a lint program on your code prior to submission?
* [ ] Have you checked if `python run_tests.py` returns no errors?

I haven't ran tests but see no reason why they should fail.

<!-- You can erase any part of this template if not applicable to your Pull Request. -->

### Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Improvement
* [ ] Breaking change
* [ ] This change is a documentation update

### Describe the changes:

- Fix the `end_time` check in `BasePlayer.play_track()`
