### PR TITLE
fix exception

### DIFF
--- a/lavalink/websocket.py
+++ b/lavalink/websocket.py
@@ -117,7 +117,7 @@ class WebSocket:
             try:
                 self._ws = await self._session.ws_connect('{}://{}:{}'.format(protocol, self._host, self._port),
                                                           headers=headers, heartbeat=60)
-            except (aiohttp.ClientConnectorError, aiohttp.WSServerHandshakeError, aiohttp.ServerDisconnectedError) as ce:
+            except (aiohttp.ClientConnectorError, aiohttp.WSServerHandshakeError, aiohttp.ServerDisconnectedError, asyncio.exceptions.TimeoutError) as ce:
                 if isinstance(ce, aiohttp.ClientConnectorError):
                     _log.warning('[Node:%s] Invalid response received; this may indicate that '
                                  'Lavalink is not running, or is running on a port different '
@@ -134,6 +134,8 @@ class WebSocket:
                     _log.warning('[Node:%s] The remote server returned code %d, the expected code was 101. This usually '
                                  'indicates that the remote server is a webserver and not Lavalink. Check your ports, '
                                  'and try again.', self._node.name, ce.status)
+                elif isinstance(ce, asyncio.exceptions.TimeoutError):
+                    _log.warning('[Node:%s] The remote server is not responding.', self._node.name)
                 else:
                     _log.exception('[Node:%s] An unknown error occurred whilst trying to establish '
                                    'a connection to Lavalink', self._node.name)


### PR DESCRIPTION
### Checks and guidelines:
<!-- Mark your checks with 'x' inside the square brackets -->

* [x] Have you checked that there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you checked that only **single quotes** are used in the code, apart from the doc-strings?
* [x] Have you run a lint program on your code prior to submission?
* [ ] Have you checked if `python run_tests.py` returns no errors?

Tests output: I don't think they're needed here

<!-- You can erase any part of this template if not applicable to your Pull Request. -->

### Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Improvement
* [ ] Breaking change
* [ ] This change is a documentation update

### Describe the changes:

- I've added timeout exception to handle such an error 
 ```
Task exception was never retrieved
future: <Task finished name='Task-17' coro=<WebSocket._connect() done, defined at /usr/local/lib/python3.10/dist-packages/lavalink/websocket.py:93> exception=TimeoutError()>
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/lavalink/websocket.py", line 157, in _connect
    await self._listen()
  File "/usr/local/lib/python3.10/dist-packages/lavalink/websocket.py", line 178, in _listen
    await self._websocket_closed(self._ws.close_code, 'AsyncIterator loop exited')
  File "/usr/local/lib/python3.10/dist-packages/lavalink/websocket.py", line 196, in _websocket_closed
    await self._connect()
  File "/usr/local/lib/python3.10/dist-packages/lavalink/websocket.py", line 157, in _connect
    await self._listen()
  File "/usr/local/lib/python3.10/dist-packages/lavalink/websocket.py", line 178, in _listen
    await self._websocket_closed(self._ws.close_code, 'AsyncIterator loop exited')
  File "/usr/local/lib/python3.10/dist-packages/lavalink/websocket.py", line 196, in _websocket_closed
    await self._connect()
  File "/usr/local/lib/python3.10/dist-packages/lavalink/websocket.py", line 118, in _connect
    self._ws = await self._session.ws_connect('{}://{}:{}'.format(protocol, self._host, self._port),
  File "/usr/local/lib/python3.10/dist-packages/aiohttp/client.py", line 779, in _ws_connect
    resp = await self.request(
  File "/usr/local/lib/python3.10/dist-packages/aiohttp/client.py", line 467, in _request
    with timer:
  File "/usr/local/lib/python3.10/dist-packages/aiohttp/helpers.py", line 720, in __exit__
    raise asyncio.TimeoutError from None
asyncio.exceptions.TimeoutError
```