### PR TITLE
fix TrackEndEvent.reason for Lavalink v4

### DIFF
--- a/lavalink/player.py
+++ b/lavalink/player.py
@@ -607,7 +607,7 @@ class DefaultPlayer(BasePlayer):
             The event that will be handled.
         """
         if isinstance(event, (TrackStuckEvent, TrackExceptionEvent)) or \
-                isinstance(event, TrackEndEvent) and event.reason == 'FINISHED':
+                isinstance(event, TrackEndEvent) and event.reason == 'finished':
             try:
                 await self.play()
             except RequestError:


### PR DESCRIPTION
### Checks and guidelines:
<!-- Mark your checks with 'x' inside the square brackets -->

* [x] Have you checked that there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you checked that only **single quotes** are used in the code, apart from the doc-strings?
* [x] Have you run a lint program on your code prior to submission?
* [ ] Have you checked if `python run_tests.py` returns no errors?

Tests output: 

<!-- You can erase any part of this template if not applicable to your Pull Request. -->

### Type of change

* [x] Bug fix
* [ ] New feature
* [ ] Improvement
* [ ] Breaking change
* [ ] This change is a documentation update

### Describe the changes:

Fixed `event.reason` being compared with "FINISHED" instead of "finished" to comply with the Lavalink v4 [TrackEndEvent](https://github.com/lavalink-devs/Lavalink/blob/v4/IMPLEMENTATION.md#trackendevent) and avoid `QueueEndEvent` being skipped as a result