### PR TITLE
Bump aiohttp version from 3.9.0 to 3.9.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     download_url='https://github.com/Devoxin/Lavalink.py/archive/{}.tar.gz'.format(version),
     keywords=['lavalink'],
     include_package_data=True,
-    install_requires=['aiohttp>=3.8.0,<3.9.0'],  # >=3.9.0,<4 is 3.8+
+    install_requires=['aiohttp>=3.8.0,<3.9.1'],  # >=3.9.0,<4 is 3.8+
     extras_require={'docs': ['sphinx',
                              'pygments',
                              'guzzle_sphinx_theme',


### PR DESCRIPTION
Added support for py3.12 people out there due aiohttp 3.9.0 not supporting py3.12

### Checks and guidelines:
<!-- Mark your checks with 'x' inside the square brackets -->

- [X] I have checked the [Pull Requests](../pulls) for the same update/change.
- [X] I have validated my changes with `python run_tests.py`, and no new errors are introduced with my pull request.

### Type of change

- [X] Internal
- [ ] Interface (affecting end-user code)
- [ ] Documentation

### Describe the changes:

<!-- Be concise, provide short summaries of what your changes consist of, and what the goal of the changes are -->
