### PR TITLE
5.3.0

### DIFF
--- a/docs/lavalink.rst
+++ b/docs/lavalink.rst
@@ -24,6 +24,14 @@ Client
 .. autoclass:: Client
     :members:
 
+DataIO
+------
+.. autoclass:: DataReader
+    :members:
+
+.. autoclass:: DataWriter
+    :members:
+
 Errors
 ------
 .. autoclass:: ClientError

--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -4,7 +4,7 @@ __title__ = 'Lavalink'
 __author__ = 'Devoxin'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2017-present Devoxin'
-__version__ = '5.2.0'
+__version__ = '5.3.0'
 
 
 from .abc import BasePlayer, DeferredAudioTrack, Source

--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -8,8 +8,10 @@ __version__ = '5.3.0'
 
 
 from typing import Type
+
 from .abc import BasePlayer, DeferredAudioTrack, Source
 from .client import Client
+from .dataio import DataReader, DataWriter
 from .errors import (AuthenticationError, ClientError, InvalidTrack, LoadError,
                      RequestError)
 from .events import (Event, IncomingWebSocketMessage, NodeChangedEvent,
@@ -25,6 +27,7 @@ from .player import DefaultPlayer
 from .playermanager import PlayerManager
 from .server import (AudioTrack, EndReason, LoadResult, LoadResultError,
                      LoadType, PlaylistInfo, Plugin, Severity)
+from .source_decoders import DEFAULT_DECODER_MAPPING
 from .stats import Penalty, Stats
 from .utils import (decode_track, encode_track, format_time, parse_time,
                     timestamp_to_millis)

--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -7,6 +7,7 @@ __copyright__ = 'Copyright 2017-present Devoxin'
 __version__ = '5.3.0'
 
 
+from typing import Type
 from .abc import BasePlayer, DeferredAudioTrack, Source
 from .client import Client
 from .errors import (AuthenticationError, ClientError, InvalidTrack, LoadError,
@@ -29,7 +30,7 @@ from .utils import (decode_track, encode_track, format_time, parse_time,
                     timestamp_to_millis)
 
 
-def listener(*events: Event):
+def listener(*events: Type[Event]):
     """
     Marks this function as an event listener for Lavalink.py.
     This **must** be used on class methods, and you must ensure that you register

--- a/lavalink/abc.py
+++ b/lavalink/abc.py
@@ -274,7 +274,7 @@ class DeferredAudioTrack(ABC, AudioTrack):
     for example.
     """
     @abstractmethod
-    async def load(self, client: 'Client'):
+    async def load(self, client: 'Client') -> Optional[str]:
         """|coro|
 
         Retrieves a base64 string that's playable by Lavalink.
@@ -288,8 +288,9 @@ class DeferredAudioTrack(ABC, AudioTrack):
 
         Returns
         -------
-        :class:`str`
+        Optional[:class:`str`]
             A Lavalink-compatible base64-encoded string containing track metadata.
+            If a track string cannot be returned, you may return ``None`` or throw a :class:`LoadError`.
         """
         raise NotImplementedError
 

--- a/lavalink/client.py
+++ b/lavalink/client.py
@@ -28,7 +28,7 @@ import logging
 import random
 from collections import defaultdict
 from inspect import getmembers, ismethod
-from typing import (Any, Callable, Dict, List, Optional, Sequence, Set, Tuple,
+from typing import (Any, Callable, Dict, Generic, List, Optional, Sequence, Set, Tuple,
                     Type, TypeVar, Union)
 
 import aiohttp
@@ -47,7 +47,7 @@ PlayerT = TypeVar('PlayerT', bound=BasePlayer)
 EventT = TypeVar('EventT', bound=Event)
 
 
-class Client:
+class Client(Generic[PlayerT]):
     """
     Represents a Lavalink client used to manage nodes and connections.
 
@@ -102,7 +102,7 @@ class Client:
         self._user_id: int = int(user_id)
         self._event_hooks = defaultdict(list)
         self.node_manager: NodeManager = NodeManager(self, regions, connect_back)
-        self.player_manager: PlayerManager = PlayerManager(self, player)
+        self.player_manager: PlayerManager[PlayerT] = PlayerManager(self, player)
         self.sources: Set[Source] = set()
 
     @property
@@ -113,7 +113,7 @@ class Client:
         return self.node_manager.nodes
 
     @property
-    def players(self) -> Dict[int, BasePlayer]:
+    def players(self) -> Dict[int, PlayerT]:
         """
         Convenience shortcut for :attr:`PlayerManager.players`.
         """
@@ -207,7 +207,7 @@ class Client:
         ----------
         events: Sequence[:class:`Event`]
             The events to remove the hooks from. This parameter can be omitted,
-            and the events registered on the function via :meth:`listener` will be used instead, if applicable.
+            and the events registered on the function via :func:`listener` will be used instead, if applicable.
             Otherwise, a default value of ``Generic`` is used instead.
         hooks: Sequence[Callable]
             A list of hook methods to remove.

--- a/lavalink/dataio.py
+++ b/lavalink/dataio.py
@@ -33,6 +33,11 @@ class DataReader:
     def __init__(self, base64_str: str):
         self._buf = BytesIO(b64decode(base64_str))
 
+    @property
+    def remaining(self) -> int:
+        """ The amount of bytes left to be read. """
+        return self._buf.getbuffer().nbytes - self._buf.tell()
+
     def _read(self, count: int):
         return self._buf.read(count)
 

--- a/lavalink/filters.py
+++ b/lavalink/filters.py
@@ -485,7 +485,7 @@ class LowPass(Filter[float]):
         ------
         :class:`ValueError`
         """
-        smoothing = float('smoothing')
+        smoothing = float(smoothing)
 
         if smoothing <= 1:
             raise ValueError('smoothing must be bigger than 1')

--- a/lavalink/player.py
+++ b/lavalink/player.py
@@ -533,6 +533,20 @@ class DefaultPlayer(BasePlayer):
 
         return self.filters.get(filter_name.lower(), None)
 
+    async def remove_filters(self, *filters: Union[Type[FilterT], str]):
+        """|coro|
+
+        Removes multiple filters from the player, undoing any effects applied to the audio.
+        This is similar to :func:`remove_filter` but instead allows you to remove multiple filters with one call.
+
+        Parameters
+        ----------
+        filters: Union[Type[:class:`Filter`], :class:`str`]
+            The filters to remove. Can be filter name, or filter class (**not** an instance of).
+        """
+        for fltr in filters:
+            await self.remove_filter(fltr)
+
     async def remove_filter(self, _filter: Union[Type[FilterT], str]):
         """|coro|
 

--- a/lavalink/server.py
+++ b/lavalink/server.py
@@ -86,7 +86,7 @@ class AudioTrack:
         The track's uploader.
     duration: :class:`int`
         The duration of the track, in milliseconds.
-    stream: :class:`bool`
+    is_stream: :class:`bool`
         Whether the track is a live-stream.
     title: :class:`str`
         The title of the track.
@@ -110,7 +110,7 @@ class AudioTrack:
     extra: Dict[str, Any]
         Any extra properties given to this AudioTrack will be stored here.
     """
-    __slots__ = ('raw', 'track', 'identifier', 'is_seekable', 'author', 'duration', 'stream', 'title', 'uri',
+    __slots__ = ('raw', 'track', 'identifier', 'is_seekable', 'author', 'duration', 'is_stream', 'title', 'uri',
                  'artwork_url', 'isrc', 'position', 'source_name', 'plugin_info', 'user_data', 'extra')
 
     def __init__(self, data: dict, requester: int = 0, **extra):
@@ -127,7 +127,7 @@ class AudioTrack:
             self.is_seekable: bool = info['isSeekable']
             self.author: str = info['author']
             self.duration: int = info['length']
-            self.stream: bool = info['isStream']
+            self.is_stream: bool = info['isStream']
             self.title: str = info['title']
             self.uri: str = info['uri']
             self.artwork_url: Optional[str] = info.get('artworkUrl')
@@ -149,6 +149,17 @@ class AudioTrack:
     @classmethod
     def from_dict(cls, mapping: dict):
         return cls(mapping)
+
+    @property
+    def stream(self) -> bool:
+        """
+        Property indicating whether this track is a stream.
+
+        .. deprecated:: 5.3.0
+            To be consistent with attribute naming, this property has been deprecated
+            in favour of ``is_stream``.
+        """
+        return self.is_stream
 
     @property
     def requester(self) -> int:

--- a/lavalink/server.py
+++ b/lavalink/server.py
@@ -25,7 +25,7 @@ This module serves to contain all entities which are deserialized using response
 the Lavalink server.
 """
 from enum import Enum as _Enum
-from typing import (TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Type, TypeVar,
+from typing import (TYPE_CHECKING, Any, Dict, List, Optional, Type, TypeVar,
                     Union)
 
 from .errors import InvalidTrack

--- a/lavalink/server.py
+++ b/lavalink/server.py
@@ -25,7 +25,7 @@ This module serves to contain all entities which are deserialized using response
 the Lavalink server.
 """
 from enum import Enum as _Enum
-from typing import (TYPE_CHECKING, Any, Dict, List, Optional, Type, TypeVar,
+from typing import (TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Type, TypeVar,
                     Union)
 
 from .errors import InvalidTrack

--- a/lavalink/source_decoders.py
+++ b/lavalink/source_decoders.py
@@ -56,6 +56,3 @@ DEFAULT_DECODER_MAPPING: Dict[str, Callable[[DataReader], Mapping[str, Any]]] = 
     'spotify': decode_lavasrc_fields,
     'applemusic': decode_lavasrc_fields
 }
-"""
-The default mapping of source-specific field decoders for use with :func:`decode_track`.
-"""

--- a/lavalink/source_decoders.py
+++ b/lavalink/source_decoders.py
@@ -27,7 +27,7 @@ from .dataio import DataReader
 
 
 def decode_probe_info(reader: DataReader) -> Mapping[str, Any]:
-    probe_info = reader.read_utf()
+    probe_info = reader.read_utf().decode()
     return {'probe_info': probe_info}
 
 

--- a/lavalink/source_decoders.py
+++ b/lavalink/source_decoders.py
@@ -32,6 +32,9 @@ def decode_probe_info(reader: DataReader) -> Mapping[str, Any]:
 
 
 def decode_lavasrc_fields(reader: DataReader) -> Mapping[str, Any]:
+    if reader.remaining <= 8:  # 8 bytes (long) = position field
+        return {}
+
     album_name = reader.read_nullable_utf()
     album_url = reader.read_nullable_utf()
     artist_url = reader.read_nullable_utf()

--- a/lavalink/source_decoders.py
+++ b/lavalink/source_decoders.py
@@ -1,0 +1,61 @@
+"""
+MIT License
+
+Copyright (c) 2017-present Devoxin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+from typing import Any, Callable, Dict, Mapping
+
+from .dataio import DataReader
+
+
+def decode_probe_info(reader: DataReader) -> Mapping[str, Any]:
+    probe_info = reader.read_utf()
+    return {'probe_info': probe_info}
+
+
+def decode_lavasrc_fields(reader: DataReader) -> Mapping[str, Any]:
+    album_name = reader.read_nullable_utf()
+    album_url = reader.read_nullable_utf()
+    artist_url = reader.read_nullable_utf()
+    artist_artwork_url = reader.read_nullable_utf()
+    preview_url = reader.read_nullable_utf()
+    is_preview = reader.read_boolean()
+
+    return {
+        'album_name': album_name,
+        'album_url': album_url,
+        'artist_url': artist_url,
+        'artist_artwork_url': artist_artwork_url,
+        'preview_url': preview_url,
+        'is_preview': is_preview
+    }
+
+
+DEFAULT_DECODER_MAPPING: Dict[str, Callable[[DataReader], Mapping[str, Any]]] = {
+    'http': decode_probe_info,
+    'local': decode_probe_info,
+    'deezer': decode_lavasrc_fields,
+    'spotify': decode_lavasrc_fields,
+    'applemusic': decode_lavasrc_fields
+}
+"""
+The default mapping of source-specific field decoders for use with :func:`decode_track`.
+"""

--- a/lavalink/transport.py
+++ b/lavalink/transport.py
@@ -181,7 +181,7 @@ class Transport:
                 try:
                     await self._handle_message(msg.json())
                 except Exception:  # pylint: disable=W0718
-                    _log.error('[Node:%s] Unexpected error occurred whilst processing websocket message', self._node.name)
+                    _log.exception('[Node:%s] Unexpected error occurred whilst processing websocket message', self._node.name)
             elif msg.type == aiohttp.WSMsgType.ERROR:
                 exc = self._ws.exception()
                 _log.error('[Node:%s] Exception in WebSocket!', self._node.name, exc_info=exc)

--- a/lavalink/utils.py
+++ b/lavalink/utils.py
@@ -162,8 +162,8 @@ def decode_track(track: str,  # pylint: disable=R0914
         A mapping of source-specific decoders to use.
         Some Lavaplayer sources have additional fields encoded on a per-sourcemanager basis, so you can
         specify a mapping of decoders that will handle decoding these additional fields. You can find some
-        example decoders within the ``source_decoders`` file. This isn't required for all sources, so ensure that you need them
-        before specifying.
+        example decoders within the ``source_decoders`` file. This isn't required for all sources, so ensure
+        that you need them before specifying.
 
         To overwrite library-provided decoders, just specify them within the mapping and the new decoders will
         be used.
@@ -174,7 +174,7 @@ def decode_track(track: str,  # pylint: disable=R0914
     """
     decoders = DEFAULT_DECODER_MAPPING.copy()
 
-    if decoders is not MISSING:
+    if source_decoders is not MISSING:
         decoders.update(source_decoders)
 
     reader = DataReader(track)

--- a/lavalink/utils.py
+++ b/lavalink/utils.py
@@ -162,7 +162,7 @@ def decode_track(track: str,  # pylint: disable=R0914
         A mapping of source-specific decoders to use.
         Some Lavaplayer sources have additional fields encoded on a per-sourcemanager basis, so you can
         specify a mapping of decoders that will handle decoding these additional fields. You can find some
-        example decoders within <TODO>. This isn't required for all sources, so ensure that you need them
+        example decoders within the ``source_decoders`` file. This isn't required for all sources, so ensure that you need them
         before specifying.
 
         To overwrite library-provided decoders, just specify them within the mapping and the new decoders will


### PR DESCRIPTION
### Checks and guidelines:
<!-- Mark your checks with 'x' inside the square brackets -->

- [x] I have checked the [Pull Requests](../pulls) for the same update/change.
- [x] I have validated my changes with `python run_tests.py`, and no new errors are introduced with my pull request.

### Type of change

- [x] Internal
- [x] Interface (affecting end-user code)
- [x] Documentation

### Describe the changes:
- [typings] Add player types to `PlayerManager` class.
- [typings] Fix `events` type for `@lavalink.listener` decorator.
- [docs] Annotate return type of `DeferredAudioTrack.load` method.
- [docs] Expose the `DataReader` and `DataWriter` classes in `DataIO`.
- [feature] Add support for per-source base64 track field decoding.
- [feature] Add `DefaultPlayer.remove_filters` method for removing multiple filters at once.
- [fix] Fix `LowPass` filter trying to convert `'smoothing'` to a float.
- [fix] Attach exception information to error log when handling websocket message.
- [misc] Renamed `AudioTrack.stream` to `AudioTrack.is_stream` for naming consistency and clarity.
  - `AudioTrack.stream` is still available but marked deprecated.