### PR TITLE
5.5.0

### DIFF
--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -4,7 +4,7 @@ __title__ = 'Lavalink'
 __author__ = 'Devoxin'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2017-present Devoxin'
-__version__ = '5.4.0'
+__version__ = '5.5.0'
 
 
 from typing import Type

--- a/lavalink/client.py
+++ b/lavalink/client.py
@@ -265,7 +265,7 @@ class Client(Generic[PlayerT]):
         return next((source for source in self.sources if source.name == source_name), None)
 
     def add_node(self, host: str, port: int, password: str, region: str, name: Optional[str] = None,
-                 ssl: bool = False, session_id: Optional[str] = None, connect: bool = True) -> Node:
+                 ssl: bool = False, session_id: Optional[str] = None, connect: bool = True, tags: Optional[Dict[str, Any]] = None) -> Node:
         """
         Shortcut for :func:`NodeManager.add_node`.
 
@@ -293,6 +293,9 @@ class Client(Generic[PlayerT]):
         connect: :class:`bool`
             Whether to immediately connect to the node after creating it.
             If ``False``, you must call :func:`Node.connect` if you require WebSocket functionality.
+        tags: Optional[Dict[:class:`str`, Any]]
+            Additional tags to attach to this node. You can use this to store additional metadata
+            that you may need to access later.
 
         Returns
         -------
@@ -300,7 +303,7 @@ class Client(Generic[PlayerT]):
             The created Node instance.
         """
         return self.node_manager.add_node(host, port, password, region, name, ssl,
-                                          session_id, connect)
+                                          session_id, connect, tags)
 
     async def get_local_tracks(self, query: str) -> LoadResult:
         """|coro|

--- a/lavalink/errors.py
+++ b/lavalink/errors.py
@@ -69,7 +69,7 @@ class RequestError(Exception):
         self.status: int = status
         self.timestamp: int = response['timestamp']
         self.error: str = response['error']
-        self.message: str = response['message']
+        self.message: str = response.get('message', '')
         self.path: str = response['path']
         self.trace: Optional[str] = response.get('trace', None)
         self.params = params

--- a/lavalink/filters.py
+++ b/lavalink/filters.py
@@ -164,6 +164,10 @@ class Karaoke(Filter[Dict[str, float]]):
         ...
 
     @overload
+    def update(self, *, filter_band: float):
+        ...
+
+    @overload
     def update(self, *, filter_width: float):
         ...
 
@@ -176,11 +180,31 @@ class Karaoke(Filter[Dict[str, float]]):
         ...
 
     @overload
+    def update(self, *, level: float, filter_band: float):
+        ...
+
+    @overload
     def update(self, *, mono_level: float, filter_width: float):
         ...
 
     @overload
+    def update(self, *, mono_level: float, filter_band: float):
+        ...
+
+    @overload
+    def update(self, *, filter_band: float, filter_width: float):
+        ...
+
+    @overload
     def update(self, *, level: float, mono_level: float, filter_width: float):
+        ...
+
+    @overload
+    def update(self, *, level: float, mono_level: float, filter_band: float):
+        ...
+
+    @overload
+    def update(self, *, level: float, mono_level: float, filter_band: float, filter_width: float):
         ...
 
     def update(self, **kwargs):

--- a/lavalink/node.py
+++ b/lavalink/node.py
@@ -59,11 +59,13 @@ class Node:
         The name the :class:`Node` is identified by.
     stats: :class:`Stats`
         The statistics of how the :class:`Node` is performing.
+    tags: Dict[:class:`str`, Any]
+        Additional tags to attach to this node.
     """
-    __slots__ = ('client', 'manager', '_transport', 'region', 'name', 'stats')
+    __slots__ = ('client', 'manager', '_transport', 'region', 'name', 'stats', 'tags')
 
     def __init__(self, manager, host: str, port: int, password: str, region: str, name: Optional[str] = None,
-                 ssl: bool = False, session_id: Optional[str] = None, connect: bool = True):
+                 ssl: bool = False, session_id: Optional[str] = None, connect: bool = True, tags: Optional[Dict[str, Any]] = None):
         self.client: 'Client' = manager.client
         self.manager: 'NodeManager' = manager
         self._transport = Transport(self, host, port, password, ssl, session_id, connect)
@@ -71,6 +73,7 @@ class Node:
         self.region: str = region
         self.name: str = name or f'{region}-{host}:{port}'
         self.stats: Stats = Stats.empty(self)
+        self.tags: Dict[str, Any] = tags or {}
 
     @property
     def session_id(self) -> Optional[str]:

--- a/lavalink/nodemanager.py
+++ b/lavalink/nodemanager.py
@@ -22,7 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 import logging
-from typing import TYPE_CHECKING, Dict, Iterator, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, Iterator, List, Optional, Tuple
 
 from .errors import ClientError
 from .node import Node
@@ -83,7 +83,7 @@ class NodeManager:
         return [n for n in self.nodes if n.available]
 
     def add_node(self, host: str, port: int, password: str, region: str, name: Optional[str] = None,
-                 ssl: bool = False, session_id: Optional[str] = None, connect: bool = True) -> Node:
+                 ssl: bool = False, session_id: Optional[str] = None, connect: bool = True, tags: Optional[Dict[str, Any]] = None) -> Node:
         """
         Adds a node to this node manager.
 
@@ -109,6 +109,9 @@ class NodeManager:
         connect: :class:`bool`
             Whether to immediately connect to the node after creating it.
             If ``False``, you must call :func:`Node.connect` if you require WebSocket functionality.
+        tags: Optional[Dict[:class:`str`, Any]]
+            Additional tags to attach to this node. You can use this to store additional metadata
+            that you may need to access later.
 
         Returns
         -------
@@ -116,7 +119,7 @@ class NodeManager:
             The created Node instance.
         """
         node = Node(self, host, port, password, region, name, ssl,
-                    session_id, connect)
+                    session_id, connect, tags)
         self.nodes.append(node)
         return node
 

--- a/lavalink/playermanager.py
+++ b/lavalink/playermanager.py
@@ -140,7 +140,26 @@ class PlayerManager(Generic[PlayerT]):
                *,
                region: Optional[str] = ...,
                endpoint: Optional[str] = ...,
+               node_filter: Optional[Callable[[Node], bool]] = ...) -> PlayerT:
+        ...
+
+    @overload
+    def create(self,
+               guild_id: int,
+               *,
+               region: Optional[str] = ...,
+               endpoint: Optional[str] = ...,
                node: Optional[Node] = ...,
+               cls: Type[CustomPlayerT]) -> CustomPlayerT:
+        ...
+
+    @overload
+    def create(self,
+               guild_id: int,
+               *,
+               region: Optional[str] = ...,
+               endpoint: Optional[str] = ...,
+               node_filter: Optional[Callable[[Node], bool]] = ...,
                cls: Type[CustomPlayerT]) -> CustomPlayerT:
         ...
 
@@ -150,6 +169,7 @@ class PlayerManager(Generic[PlayerT]):
                region: Optional[str] = None,
                endpoint: Optional[str] = None,
                node: Optional[Node] = None,
+               node_filter: Optional[Callable[[Node], bool]] = None,
                cls: Optional[Type[CustomPlayerT]] = None) -> Union[CustomPlayerT, PlayerT]:
         """
         Creates a player if one doesn't exist with the given information.
@@ -177,6 +197,11 @@ class PlayerManager(Generic[PlayerT]):
         node: Optional[:class:`Node`]
             The node to put the player on.
             Defaults to ``None``, which selects the node with the lowest penalty.
+        node_filter: Optional[Callable[[:class:`Node`], :class:`bool`]]
+            A filter to use when selecting nodes this player can be assigned to.
+            This cannot be used with the ``node`` parameter.
+            Nodes are filtered based on the given predicate, and then again based on their penalty score.
+            If no nodes are found after filtering, all available nodes will be considered without filtering.
         cls: Optional[Type[:class:`BasePlayer`]]
             The player class to use when instantiating a new player.
             Defaults to ``None`` which uses the player class provided to :class:`Client`.
@@ -207,7 +232,16 @@ class PlayerManager(Generic[PlayerT]):
         if not issubclass(cls, BasePlayer):  # type: ignore
             raise ValueError('Player must implement BasePlayer.')
 
-        if endpoint:  # Prioritise endpoint over region parameter
+        if node is not None and node_filter is not None:
+            raise ValueError('node and node_filter may not be specified together')
+
+        if node_filter is not None:
+            user_filtered = [n for n in self.client.node_manager.available_nodes if node_filter(n)]
+
+            if user_filtered:
+                node = min(user_filtered, key=lambda node: node.penalty)
+
+        if node is None and endpoint is not None:  # Prioritise endpoint over region parameter
             region = self.client.node_manager.get_region(endpoint)
 
         best_node = node or self.client.node_manager.find_ideal_node(region)

--- a/lavalink/transport.py
+++ b/lavalink/transport.py
@@ -308,7 +308,8 @@ class Transport:
         elif event_type == 'WebSocketClosedEvent':
             event = WebSocketClosedEvent(player, data['code'], data['reason'], data['byRemote'])
         else:
-            _log.warning('[Node:%s] Unknown event received of type \'%s\'', self._node.name, event_type)
+            if not self.client.has_listeners(IncomingWebSocketMessage):
+                _log.warning('[Node:%s] Unknown event received of type \'%s\'', self._node.name, event_type)
             return
 
         await self.client._dispatch_event(event)


### PR DESCRIPTION
### Checks and guidelines:
<!-- Mark your checks with 'x' inside the square brackets -->

- [X] I have checked the [Pull Requests](../pulls) for the same update/change.
- [X] I have validated my changes with `python run_tests.py`, and no new errors are introduced with my pull request.

### Type of change

- [X] Internal
- [X] Interface (affecting end-user code)
- [X] Documentation

### Describe the changes:

- Only log `Unknown event` if there are no listeners for custom events.
- Ensure players are always destroyed, even if they're not in the internal cache.
- Add support for custom tags on nodes.
- Add missing `filter_band` overload for the Karaoke filter.
- `message` can be non-existent within `RequestError`.
  - This is undocumented and supposedly not expected at all, but this seems to be an issue that can happen.
