### PR TITLE
Bump required Python version to 3.8+ and update typings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <img align="right" src="https://raw.githubusercontent.com/devoxin/Lavalink.py/master/.github/assets/library_icon.png" height="150" width="150">
 
 # Lavalink.py
-[![Python](https://img.shields.io/badge/Python-3.6%20%7C%203.7%20%7C%203.8%20%7C%203.9%20%7C%203.10-blue.svg)](https://www.python.org) [![Codacy Badge](https://app.codacy.com/project/badge/Grade/428eebed5a2e467fb038eacfa1d92e62)](https://www.codacy.com/gh/Devoxin/Lavalink.py/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=Devoxin/Lavalink.py&amp;utm_campaign=Badge_Grade) [![License](https://img.shields.io/github/license/Devoxin/Lavalink.py.svg)](LICENSE) [![Documentation Status](https://readthedocs.org/projects/lavalink/badge/?version=development)](https://lavalink.readthedocs.io/en/development/?badge=development)
+[![Python](https://img.shields.io/badge/Python-3.8%20%7C%203.9%20%7C%203.10-blue.svg)](https://www.python.org) [![Codacy Badge](https://app.codacy.com/project/badge/Grade/428eebed5a2e467fb038eacfa1d92e62)](https://www.codacy.com/gh/Devoxin/Lavalink.py/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=Devoxin/Lavalink.py&amp;utm_campaign=Badge_Grade) [![License](https://img.shields.io/github/license/Devoxin/Lavalink.py.svg)](LICENSE) [![Documentation Status](https://readthedocs.org/projects/lavalink/badge/?version=development)](https://lavalink.readthedocs.io/en/development/?badge=development)
 
 Lavalink.py is a wrapper for [Lavalink] which abstracts away most of the code necessary to use Lavalink, allowing for easier integration into your projects, while still promising full API coverage and powerful tools to get the most out of it.
 

--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -4,7 +4,7 @@ __title__ = 'Lavalink'
 __author__ = 'Devoxin'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2017-present Devoxin'
-__version__ = '5.7.0'
+__version__ = '5.8.0'
 
 
 from typing import Type

--- a/lavalink/__init__.py
+++ b/lavalink/__init__.py
@@ -4,7 +4,7 @@ __title__ = 'Lavalink'
 __author__ = 'Devoxin'
 __license__ = 'MIT'
 __copyright__ = 'Copyright 2017-present Devoxin'
-__version__ = '5.7.2'
+__version__ = '5.7.0'
 
 
 from typing import Type

--- a/lavalink/client.py
+++ b/lavalink/client.py
@@ -44,7 +44,6 @@ _log = logging.getLogger(__name__)
 
 PlayerT = TypeVar('PlayerT', bound=BasePlayer)
 EventT = TypeVar('EventT', bound=Event)
-ClassT = TypeVar('ClassT', bound=object)
 
 
 class Client(Generic[PlayerT]):

--- a/lavalink/client.py
+++ b/lavalink/client.py
@@ -44,6 +44,7 @@ _log = logging.getLogger(__name__)
 
 PlayerT = TypeVar('PlayerT', bound=BasePlayer)
 EventT = TypeVar('EventT', bound=Event)
+ClassT = TypeVar('ClassT', bound=object)
 
 
 class Client(Generic[PlayerT]):
@@ -160,7 +161,7 @@ class Client(Generic[PlayerT]):
             if hook not in event_hooks:
                 event_hooks.append(hook)
 
-    def add_event_hooks(self, cls: Any):  # TODO: I don't think Any is the correct type here...
+    def add_event_hooks(self, cls: object):
         """
         Scans the provided class ``cls`` for functions decorated with :func:`listener`,
         and sets them up to process Lavalink events.
@@ -181,7 +182,7 @@ class Client(Generic[PlayerT]):
 
         Parameters
         ----------
-        cls: Any
+        cls: object
             An instance of a class containing event hook methods.
         """
         methods = getmembers(cls, predicate=lambda meth: hasattr(meth, '__name__')
@@ -198,7 +199,7 @@ class Client(Generic[PlayerT]):
             else:
                 self._event_hooks['Generic'].append(listener)
 
-    def remove_event_hooks(self, *, events: Optional[Sequence[EventT]] = None, hooks: Sequence[Callable]):
+    def remove_event_hooks(self, *, events: Optional[Sequence[Type[EventT]]] = None, hooks: Sequence[Callable]):
         """
         Removes the given hooks from the event hook registry.
 

--- a/lavalink/server.py
+++ b/lavalink/server.py
@@ -25,8 +25,8 @@ This module serves to contain all entities which are deserialized using response
 the Lavalink server.
 """
 from enum import Enum as _Enum
-from typing import (TYPE_CHECKING, Any, Dict, List, Optional, Type, TypeVar,
-                    Union, cast)
+from typing import (TYPE_CHECKING, Any, Dict, List, Literal, Optional, Type,
+                    TypedDict, TypeVar, Union)
 
 from .errors import InvalidTrack
 
@@ -55,6 +55,9 @@ class Enum(_Enum):
                 return cls(other)
             except ValueError as error:
                 raise ValueError(f'{other} is not a valid {cls.__name__} enum!') from error
+
+    def __str__(self):
+        return self.value
 
 
 class AudioTrack:
@@ -261,6 +264,12 @@ class LoadResultError:
         self.severity: Severity = Severity.from_str(error['severity'])
         self.cause: str = error['cause']
 
+    def __str__(self):
+        return f'{self.message}: {self.cause} ({self.severity})'
+
+    def __repr__(self):
+        return f'<LoadResultError severity={self.severity} message={self.message} cause={self.cause}>'
+
 
 class LoadResult:
     """
@@ -380,3 +389,108 @@ class Plugin:
 
     def __repr__(self):
         return f'<Plugin name={self.name} version={self.version}>'
+
+
+class RawPlugin(TypedDict):
+    name: str
+    version: str
+
+
+class RawPlayerState(TypedDict):
+    time: int
+    position: int
+    connected: bool
+    ping: int
+
+
+class RawPlayerVoiceState(TypedDict):
+    token: str
+    endpoint: str
+    sessionId: str
+
+
+class RawPlayer(TypedDict):
+    guildId: str
+    track: Optional[Dict[str, Any]]  # TODO
+    volume: int
+    paused: bool
+    state: RawPlayerState
+    voice: RawPlayerVoiceState
+    filters: Dict[str, Any]  # TODO, however the keys are NotRequired (>=3.11)
+
+
+class RawIpBlock(TypedDict):
+    type: Literal['Inet4Address', 'Inet6Address']
+    size: str
+
+
+class RawFailingAddress(TypedDict):
+    failingAddress: str
+    failingTimestamp: int
+    failingTime: str
+
+
+class RawRouteplannerDetails(TypedDict):
+    ipBlock: RawIpBlock
+    failingAddresses: List[RawFailingAddress]
+    rotateIndex: str
+    ipIndex: str
+    currentAddress: str
+    currentAddressIndex: str
+    blockIndex: str
+
+
+class RawVersion(TypedDict):
+    semver: str
+    major: int
+    minor: int
+    patch: int
+    preRelease: Optional[str]
+    build: Optional[str]
+
+
+class RawGit(TypedDict):
+    branch: str
+    commit: str
+    commitTime: int
+
+
+class RawInfo(TypedDict):
+    version: RawVersion
+    buildTime: int
+    git: RawGit
+    jvm: str
+    lavaplayer: str
+    sourceManagers: List[str]
+    filters: List[str]
+    plugins: List[RawPlugin]
+
+
+class RawMemory(TypedDict):
+    free: int
+    used: int
+    allocated: int
+    reservable: int
+
+
+class RawCpu(TypedDict):
+    cores: int
+    systemLoad: float
+    lavalinkLoad: float
+
+
+class RawStats(TypedDict):
+    players: int
+    playingPlayers: int
+    uptime: int
+    memory: RawMemory
+    cpu: RawCpu
+    frameStats: Literal[None]
+
+
+class RawSession(TypedDict):
+    resuming: bool
+    timeout: int
+
+
+RawRouteplanner = TypedDict('RawRouteplanner', {'class': str, 'details': RawRouteplannerDetails})

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     download_url='https://github.com/Devoxin/Lavalink.py/archive/{}.tar.gz'.format(version),
     keywords=['lavalink'],
     include_package_data=True,
-    install_requires=['aiohttp>=3.8.0,<3.9.0'],  # >=3.9.0,<4 is 3.8+
+    install_requires=['aiohttp>=3.9.0,<4'],  # >=3.9.0,<4 is 3.8+
     extras_require={'docs': ['sphinx',
                              'pygments',
                              'guzzle_sphinx_theme',

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     download_url='https://github.com/Devoxin/Lavalink.py/archive/{}.tar.gz'.format(version),
     keywords=['lavalink'],
     include_package_data=True,
-    install_requires=['aiohttp>=3.9.0,<4'],  # >=3.9.0,<4 is 3.8+
+    install_requires=['aiohttp>=3.9.0,<4'],
     extras_require={'docs': ['sphinx',
                              'pygments',
                              'guzzle_sphinx_theme',


### PR DESCRIPTION
### Checks and guidelines:
<!-- Mark your checks with 'x' inside the square brackets -->

- [x] I have checked the [Pull Requests](../pulls) for the same update/change.
- [x] I have validated my changes with `python run_tests.py`, and no new errors are introduced with my pull request.

### Type of change

- [x] Internal
- [x] Interface (affecting end-user code)
- [x] Documentation

### Describe the changes:
Bumps the minimum Python version to 3.8. There are also a few internal changes leveraging 3.8 features, such as `typing.TypedDict`. With this, I have included typings for methods that return raw objects from Lavalink.
