### PR TITLE
Refactor WebSocket to avoid extended blocking

### DIFF
--- a/lavalink/abc.py
+++ b/lavalink/abc.py
@@ -195,11 +195,11 @@ class BasePlayer(ABC):
             try:
                 playable_track = await track.load(self.client)
             except LoadError as load_error:
-                await self.client._dispatch_event(TrackLoadFailedEvent(self, track, load_error))
+                self.client._dispatch_event(TrackLoadFailedEvent(self, track, load_error))
                 return
 
         if playable_track is None:  # This should only fire when a DeferredAudioTrack fails to yield a base64 track string.
-            await self.client._dispatch_event(TrackLoadFailedEvent(self, track, None))  # type: ignore
+            self.client._dispatch_event(TrackLoadFailedEvent(self, track, None))  # type: ignore
             return
 
         self._next = track

--- a/lavalink/player.py
+++ b/lavalink/player.py
@@ -292,7 +292,7 @@ class DefaultPlayer(BasePlayer):
         if not track:
             if not self.queue:
                 await self.stop()  # Also sets current to None.
-                await self.client._dispatch_event(QueueEndEvent(self))
+                self.client._dispatch_event(QueueEndEvent(self))
                 return
 
             pop_at = randrange(len(self.queue)) if self.shuffle else 0
@@ -619,7 +619,7 @@ class DefaultPlayer(BasePlayer):
             try:
                 await self.play()
             except RequestError as error:
-                await self.client._dispatch_event(PlayerErrorEvent(self, error))
+                self.client._dispatch_event(PlayerErrorEvent(self, error))
                 _log.exception('[DefaultPlayer:%d] Encountered a request error whilst starting a new track.', self.guild_id)
 
     async def update_state(self, state: dict):
@@ -683,7 +683,7 @@ class DefaultPlayer(BasePlayer):
             if self.filters:
                 await self._apply_filters()
 
-            await self.client._dispatch_event(NodeChangedEvent(self, old_node, node))
+            self.client._dispatch_event(NodeChangedEvent(self, old_node, node))
         finally:
             self._internal_pause = False
 

--- a/lavalink/transport.py
+++ b/lavalink/transport.py
@@ -52,12 +52,14 @@ LAVALINK_API_VERSION = 'v4'
 
 class Transport:
     """ The class responsible for handling connections to a Lavalink server. """
-    __slots__ = ('client', '_node', '_session', '_ws', '_message_queue', 'trace_requests',
+    __slots__ = ('client', '_node', '_loop', '_session', '_ws', '_message_queue', 'trace_requests',
                  '_host', '_port', '_password', '_ssl', 'session_id', '_read_task', '_destroyed')
 
-    def __init__(self, node, host: str, port: int, password: str, ssl: bool, session_id: Optional[str], connect: bool = True):
+    def __init__(self, node, host: str, port: int, password: str, ssl: bool, session_id: Optional[str],
+                 connect: bool = True):
         self.client: 'Client' = node.client
         self._node: 'Node' = node
+        self._loop = asyncio.get_event_loop()
 
         self._session: aiohttp.ClientSession = self.client._session
         self._ws: Optional[aiohttp.ClientWebSocketResponse] = None
@@ -115,8 +117,7 @@ class Transport:
             except Exception:  # pylint: disable=W0718
                 pass
 
-        loop = asyncio.get_event_loop()
-        return loop.create_task(self._connect())
+        return self._loop.create_task(self._connect())
 
     async def destroy(self):
         """|coro|
@@ -184,7 +185,7 @@ class Transport:
 
                     self._message_queue.clear()
 
-                self._read_task = asyncio.create_task(self._listen())
+                self._read_task = self._loop.create_task(self._listen())
                 break
 
     async def _listen(self):
@@ -210,11 +211,7 @@ class Transport:
 
             if msg.type == aiohttp.WSMsgType.TEXT and msg.data is not None:
                 _log.debug('[Node:%s] Received WebSocket message: %s', self._node.name, msg.data)
-
-                try:
-                    await self._handle_message(msg.json())
-                except Exception:  # pylint: disable=W0718
-                    _log.exception('[Node:%s] Unexpected error occurred whilst processing websocket message', self._node.name)
+                self._loop.create_task(self._handle_message_safe(msg))
 
         if close_code is None:
             ws_close_code = self._ws.close_code
@@ -227,6 +224,12 @@ class Transport:
         await self._node.manager._handle_node_disconnect(self._node)
         self.client._dispatch_event(NodeDisconnectedEvent(self._node, close_code, close_reason))
         self.connect()
+
+    async def _handle_message_safe(self, msg: aiohttp.WSMessage):
+        try:
+            await self._handle_message(msg.json())
+        except Exception:  # pylint: disable=W0718
+            _log.exception('[Node:%s] Unexpected error occurred whilst processing websocket message', self._node.name)
 
     async def _handle_message(self, data: Union[Dict[Any, Any], List[Any]]):
         """

--- a/lavalink/transport.py
+++ b/lavalink/transport.py
@@ -155,22 +155,20 @@ class Transport:
                 self._ws = await self._session.ws_connect(f'{protocol}://{self._host}:{self._port}/{LAVALINK_API_VERSION}/websocket',
                                                           headers=headers,
                                                           heartbeat=60)
-            except (aiohttp.ClientConnectorError, aiohttp.WSServerHandshakeError, aiohttp.ServerDisconnectedError) as error:
-                if isinstance(error, aiohttp.ClientConnectorError):
-                    _log.warning('[Node:%s] Invalid response received; is the server running on the correct port?',
-                                 self._node.name)
-                elif isinstance(error, aiohttp.WSServerHandshakeError):
-                    if error.status in (401, 403):  # Special handling for 401/403 (Unauthorized/Forbidden).
-                        _log.warning('[Node:%s] Authentication failed while trying to establish a connection to the node.',
-                                     self._node.name)
-                        # We shouldn't try to establish any more connections as correcting this particular error
-                        # would require the cog to be reloaded (or the bot to be rebooted), so further attempts
-                        # would be futile, and a waste of resources.
-                    else:
-                        _log.warning('[Node:%s] Received code \'%d\' (expected \'101\'). Check your server\'s ports and try again.',
-                                     self._node.name, error.status)
+            except aiohttp.WSServerHandshakeError as handshake_error:
+                if handshake_error.status in (401, 403):  # Special handling for 401/403 (Unauthorized/Forbidden).
+                    _log.warning('[Node:%s] Authentication failed while trying to establish a connection to the node.', self._node.name)
+                    # We shouldn't try to establish any more connections as correcting this particular error
+                    # would require the cog to be reloaded (or the bot to be rebooted), so further attempts
+                    # would be futile, and a waste of resources.
+                else:
+                    _log.warning('[Node:%s] Received code \'%d\' (expected \'101\'). Check your server\'s ports and try again.',
+                                 self._node.name, handshake_error.status)
 
-                    return
+                return
+            except Exception as exc:  # pylint: disable=W0718
+                if isinstance(exc, aiohttp.ClientConnectorError):
+                    _log.warning('[Node:%s] Invalid response received; is the server running on the correct port?', self._node.name)
                 else:
                     _log.exception('[Node:%s] An unknown error occurred whilst trying to establish a connection to Lavalink', self._node.name)
 
@@ -200,7 +198,7 @@ class Transport:
             msg = await self._ws.receive()
 
             if msg.type in CLOSE_TYPES:
-                _log.debug('[Node:%s] Received close frame with code %d.', self._node.name, msg.data)
+                _log.debug('[Node:%s] Received close frame with code %s.', self._node.name, msg.data)
                 close_code = msg.data
                 close_reason = msg.extra
                 break

--- a/lavalink/transport.py
+++ b/lavalink/transport.py
@@ -184,8 +184,8 @@ class Transport:
 
                     self._message_queue.clear()
 
-            self._read_task = asyncio.create_task(self._listen())
-            break
+                self._read_task = asyncio.create_task(self._listen())
+                break
 
     async def _listen(self):
         """ Listens for websocket messages. """

--- a/lavalink/transport.py
+++ b/lavalink/transport.py
@@ -198,7 +198,6 @@ class Transport:
 
         while True:
             msg = await self._ws.receive()
-            _log.debug('[Node:%s] Received WebSocket message: %s', self._node.name, msg.data)
 
             if msg.type in CLOSE_TYPES:
                 _log.debug('[Node:%s] Received close frame with code %d.', self._node.name, msg.data)
@@ -211,6 +210,8 @@ class Transport:
                 _log.error('[Node:%s] Exception in WebSocket!', self._node.name, exc_info=exc)
 
             if msg.type == aiohttp.WSMsgType.TEXT and msg.data is not None:
+                _log.debug('[Node:%s] Received WebSocket message: %s', self._node.name, msg.data)
+
                 try:
                     await self._handle_message(msg.json())
                 except Exception:  # pylint: disable=W0718

--- a/lavalink/transport.py
+++ b/lavalink/transport.py
@@ -43,8 +43,8 @@ if TYPE_CHECKING:
 _log = logging.getLogger(__name__)
 CLOSE_TYPES = (
     aiohttp.WSMsgType.CLOSE,
-    aiohttp.WSMsgType.CLOSING,
-    aiohttp.WSMsgType.CLOSED
+    # aiohttp.WSMsgType.CLOSING,
+    # aiohttp.WSMsgType.CLOSED
 )
 MESSAGE_QUEUE_MAX_SIZE = 25
 LAVALINK_API_VERSION = 'v4'
@@ -53,7 +53,7 @@ LAVALINK_API_VERSION = 'v4'
 class Transport:
     """ The class responsible for handling connections to a Lavalink server. """
     __slots__ = ('client', '_node', '_session', '_ws', '_message_queue', 'trace_requests',
-                 '_host', '_port', '_password', '_ssl', 'session_id', '_destroyed')
+                 '_host', '_port', '_password', '_ssl', 'session_id', '_read_task', '_destroyed')
 
     def __init__(self, node, host: str, port: int, password: str, ssl: bool, session_id: Optional[str], connect: bool = True):
         self.client: 'Client' = node.client
@@ -70,6 +70,7 @@ class Transport:
         self._ssl: bool = ssl
 
         self.session_id: Optional[str] = session_id
+        self._read_task: Optional[asyncio.Task] = None
         self._destroyed: bool = False
 
         if connect:
@@ -90,12 +91,30 @@ class Transport:
 
         Shuts down the websocket connection if there is one.
         """
+        if self._read_task is not None:
+            try:
+                self._read_task.cancel()
+            except Exception:  # pylint: disable=W0718
+                # Shouldn't need any specific handling.
+                pass
+
         if self._ws:
-            await self._ws.close(code=code)
-            self._ws = None
+            try:
+                await self._ws.close(code=code)
+            finally:
+                self._ws = None
 
     def connect(self) -> asyncio.Task:
         """ Attempts to establish a connection to Lavalink. """
+        if self._destroyed:
+            raise IOError('Cannot instantiate any connections with a closed session!')
+
+        if self._read_task is not None:
+            try:
+                self._read_task.cancel()
+            except Exception:  # pylint: disable=W0718
+                pass
+
         loop = asyncio.get_event_loop()
         return loop.create_task(self._connect())
 
@@ -131,6 +150,7 @@ class Transport:
 
         while not self.ws_connected and not self._destroyed:
             attempt += 1
+
             try:
                 self._ws = await self._session.ws_connect(f'{protocol}://{self._host}:{self._port}/{LAVALINK_API_VERSION}/websocket',
                                                           headers=headers,
@@ -158,7 +178,7 @@ class Transport:
                 await asyncio.sleep(backoff)
             else:
                 _log.info('[Node:%s] WebSocket connection established', self._node.name)
-                await self.client._dispatch_event(NodeConnectedEvent(self._node))
+                self.client._dispatch_event(NodeConnectedEvent(self._node))
 
                 if self._message_queue:
                     for message in self._message_queue:
@@ -166,59 +186,47 @@ class Transport:
 
                     self._message_queue.clear()
 
-                attempt = 0
-                await self._listen()
+            self._read_task = asyncio.create_task(self._listen())
+            break
 
     async def _listen(self):
         """ Listens for websocket messages. """
         close_code: Optional[aiohttp.WSCloseCode] = None
-        close_reason: Optional[str] = 'Improper websocket closure'
+        close_reason: Optional[str] = 'Closed without close frame (improper closure)'
 
         assert self._ws is not None
 
-        async for msg in self._ws:
+        while True:
+            msg = await self._ws.receive()
             _log.debug('[Node:%s] Received WebSocket message: %s', self._node.name, msg.data)
 
-            if msg.type == aiohttp.WSMsgType.TEXT:
-                try:
-                    await self._handle_message(msg.json())
-                except Exception:  # pylint: disable=W0718
-                    _log.exception('[Node:%s] Unexpected error occurred whilst processing websocket message', self._node.name)
-            elif msg.type == aiohttp.WSMsgType.ERROR:
-                exc = self._ws.exception()
-                _log.error('[Node:%s] Exception in WebSocket!', self._node.name, exc_info=exc)
-                close_code = aiohttp.WSCloseCode.INTERNAL_ERROR
-                close_reason = 'WebSocket error'
-                break
-            elif msg.type in CLOSE_TYPES:
+            if msg.type in CLOSE_TYPES:
                 _log.debug('[Node:%s] Received close frame with code %d.', self._node.name, msg.data)
                 close_code = msg.data
                 close_reason = msg.extra
                 break
 
-        ws_close_code = self._ws.close_code
+            if msg.type == aiohttp.WSMsgType.ERROR:
+                exc = self._ws.exception()
+                _log.error('[Node:%s] Exception in WebSocket!', self._node.name, exc_info=exc)
 
-        if close_code is None and ws_close_code is not None:
-            close_code = aiohttp.WSCloseCode(ws_close_code)
+            if msg.type == aiohttp.WSMsgType.TEXT and msg.data is not None:
+                try:
+                    await self._handle_message(msg.json())
+                except Exception:  # pylint: disable=W0718
+                    _log.exception('[Node:%s] Unexpected error occurred whilst processing websocket message', self._node.name)
 
-        await self.close(close_code or aiohttp.WSCloseCode.ABNORMAL_CLOSURE)
-        await self._websocket_closed(close_code, close_reason)
+        if close_code is None:
+            ws_close_code = self._ws.close_code
 
-    async def _websocket_closed(self, code: Optional[int] = None, reason: Optional[str] = None):
-        """
-        Handles when the websocket is closed.
+            if ws_close_code is not None:
+                close_code = aiohttp.WSCloseCode(ws_close_code)
 
-        Parameters
-        ----------
-        code: Optional[:class:`int`]
-            The response code.
-        reason: Optional[:class:`str`]
-            Reason why the websocket was closed. Defaults to ``None``.
-        """
-        _log.warning('[Node:%s] WebSocket disconnected with the following: code=%s reason=%s', self._node.name, code, reason)
+        _log.warning('[Node:%s] WebSocket disconnected with the following: code=%s reason=%s', self._node.name, close_code, close_reason)
         self._ws = None
         await self._node.manager._handle_node_disconnect(self._node)
-        await self.client._dispatch_event(NodeDisconnectedEvent(self._node, code, reason))
+        self.client._dispatch_event(NodeDisconnectedEvent(self._node, close_code, close_reason))
+        self.connect()
 
     async def _handle_message(self, data: Union[Dict[Any, Any], List[Any]]):
         """
@@ -230,7 +238,7 @@ class Transport:
             The payload received from the Lavalink server.
         """
         if self.client.has_listeners(IncomingWebSocketMessage):
-            await self.client._dispatch_event(IncomingWebSocketMessage(data.copy(), self._node))
+            self.client._dispatch_event(IncomingWebSocketMessage(data.copy(), self._node))
 
         if not isinstance(data, dict) or 'op' not in data:
             return
@@ -240,10 +248,10 @@ class Transport:
         if op == 'ready':
             self.session_id = data['sessionId']
             await self._node.manager._handle_node_ready(self._node)
-            await self.client._dispatch_event(NodeReadyEvent(self._node, data['sessionId'], data['resumed']))
+            self.client._dispatch_event(NodeReadyEvent(self._node, data['sessionId'], data['resumed']))
         elif op == 'playerUpdate':
             guild_id = int(data['guildId'])
-            player: 'BasePlayer' = self.client.player_manager.get(guild_id)  # type: ignore
+            player: Optional['BasePlayer'] = self.client.player_manager.get(guild_id)  # type: ignore
 
             if not player:
                 _log.debug('[Node:%s] Received playerUpdate for non-existent player! GuildId: %d', self._node.name, guild_id)
@@ -256,7 +264,7 @@ class Transport:
 
             state = data['state']
             await player.update_state(state)
-            await self.client._dispatch_event(PlayerUpdateEvent(player, state))
+            self.client._dispatch_event(PlayerUpdateEvent(player, state))
         elif op == 'stats':
             self._node.stats = Stats(self._node, data)
         elif op == 'event':
@@ -273,7 +281,7 @@ class Transport:
         data: :class:`dict`
             The data given from Lavalink.
         """
-        player: 'BasePlayer' = self.client.player_manager.get(int(data['guildId']))  # type: ignore
+        player: Optional['BasePlayer'] = self.client.player_manager.get(int(data['guildId']))  # type: ignore
         event_type = data['type']
 
         if not player:
@@ -315,7 +323,7 @@ class Transport:
                 _log.warning('[Node:%s] Unknown event received of type \'%s\'', self._node.name, event_type)
             return
 
-        await self.client._dispatch_event(event)
+        self.client._dispatch_event(event)
 
         if player:
             try:

--- a/lavalink/transport.py
+++ b/lavalink/transport.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
 
 _log = logging.getLogger(__name__)
 CLOSE_TYPES = (
-    aiohttp.WSMsgType.CLOSE,
+    # aiohttp.WSMsgType.CLOSE,
     aiohttp.WSMsgType.CLOSING,
     aiohttp.WSMsgType.CLOSED
 )
@@ -198,9 +198,9 @@ class Transport:
             msg = await self._ws.receive()
 
             if msg.type in CLOSE_TYPES:
-                _log.debug('[Node:%s] Received close frame with code %s.', self._node.name, msg.data)
                 close_code = msg.data
                 close_reason = msg.extra
+                _log.debug('[Node:%s] Received close frame with code %s.', self._node.name, close_code)
                 break
 
             if msg.type == aiohttp.WSMsgType.ERROR:

--- a/lavalink/transport.py
+++ b/lavalink/transport.py
@@ -43,8 +43,8 @@ if TYPE_CHECKING:
 _log = logging.getLogger(__name__)
 CLOSE_TYPES = (
     aiohttp.WSMsgType.CLOSE,
-    # aiohttp.WSMsgType.CLOSING,
-    # aiohttp.WSMsgType.CLOSED
+    aiohttp.WSMsgType.CLOSING,
+    aiohttp.WSMsgType.CLOSED
 )
 MESSAGE_QUEUE_MAX_SIZE = 25
 LAVALINK_API_VERSION = 'v4'
@@ -208,6 +208,7 @@ class Transport:
             if msg.type == aiohttp.WSMsgType.ERROR:
                 exc = self._ws.exception()
                 _log.error('[Node:%s] Exception in WebSocket!', self._node.name, exc_info=exc)
+                break
 
             if msg.type == aiohttp.WSMsgType.TEXT and msg.data is not None:
                 _log.debug('[Node:%s] Received WebSocket message: %s', self._node.name, msg.data)


### PR DESCRIPTION
### Checks and guidelines:
<!-- Mark your checks with 'x' inside the square brackets -->

- [x] I have checked the [Pull Requests](../pulls) for the same update/change.
- [x] I have validated my changes with `python run_tests.py`, and no new errors are introduced with my pull request.

### Type of change

- [x] Internal
- [ ] Interface (affecting end-user code)
- [ ] Documentation

### Describe the changes:
This PR refactors how the websocket connection is handled, with the idea being to offer additional resilience against zombie connections, as well as handling messages as tasks to avoid blocking websocket message receiving. This has been tested in a large bot for the last few days and has been running smoothly, with no more sporadic errors due to websocket sessions being blocked and not reconnected.